### PR TITLE
Rename all of T* and P* but keep backward comparability.

### DIFF
--- a/src/cairo.nim
+++ b/src/cairo.nim
@@ -1,58 +1,55 @@
-#* cairo - a vector graphics library with display and print output
-# *
-# * Copyright © 2002 University of Southern California
-# * Copyright © 2005 Red Hat, Inc.
-# *
-# * This library is free software; you can redistribute it and/or
-# * modify it either under the terms of the GNU Lesser General Public
-# * License version 2.1 as published by the Free Software Foundation
-# * (the "LGPL") or, at your option, under the terms of the Mozilla
-# * Public License Version 1.1 (the "MPL"). If you do not alter this
-# * notice, a recipient may use your version of this file under either
-# * the MPL or the LGPL.
-# *
-# * You should have received a copy of the LGPL along with this library
-# * in the file COPYING-LGPL-2.1; if not, write to the Free Software
-# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-# * You should have received a copy of the MPL along with this library
-# * in the file COPYING-MPL-1.1
-# *
-# * The contents of this file are subject to the Mozilla Public License
-# * Version 1.1 (the "License"); you may not use this file except in
-# * compliance with the License. You may obtain a copy of the License at
-# * http://www.mozilla.org/MPL/
-# *
-# * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY
-# * OF ANY KIND, either express or implied. See the LGPL or the MPL for
-# * the specific language governing rights and limitations.
-# *
-# * The Original Code is the cairo graphics library.
-# *
-# * The Initial Developer of the Original Code is University of Southern
-# * California.
-# *
-# * Contributor(s):
-# *	Carl D. Worth <cworth@cworth.org>
-# #*
-# *  This FreePascal binding generated August 26, 2005
-# *  by Jeffrey Pohlmeyer <yetanothergeek@yahoo.com>
+# cairo - a vector graphics library with display and print output
 #
+# Copyright © 2002 University of Southern California
+# Copyright © 2005 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it either under the terms of the GNU Lesser General Public
+# License version 2.1 as published by the Free Software Foundation
+# (the "LGPL") or, at your option, under the terms of the Mozilla
+# Public License Version 1.1 (the "MPL"). If you do not alter this
+# notice, a recipient may use your version of this file under either
+# the MPL or the LGPL.
+#
+# You should have received a copy of the LGPL along with this library
+# in the file COPYING-LGPL-2.1; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+# You should have received a copy of the MPL along with this library
+# in the file COPYING-MPL-1.1
+#
+# The contents of this file are subject to the Mozilla Public License
+# Version 1.1 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+# http://www.mozilla.org/MPL/
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY
+# OF ANY KIND, either express or implied. See the LGPL or the MPL for
+# the specific language governing rights and limitations.
+#
+# The Original Code is the cairo graphics library.
+#
+# The Initial Developer of the Original Code is University of Southern
+# California.
+#
+# Contributor(s):
+#	Carl D. Worth <cworth@cworth.org>
+#
+# This FreePascal binding generated August 26, 2005
+# by Jeffrey Pohlmeyer <yetanothergeek@yahoo.com>
+#
+# - Updated to cairo version 1.4
+# - Grouped OS specific fuctions in separated units
+# - Organized the functions by group and ordered exactly as the c header
+# - Cleared parameter list syntax according to pascal standard
+#
+# By Luiz Américo Pereira Câmara
+# October 2007
 
-#
-#  - Updated to cairo version 1.4
-#  - Grouped OS specific fuctions in separated units
-#  - Organized the functions by group and ordered exactly as the c header
-#  - Cleared parameter list syntax according to pascal standard
-#
-#  By Luiz Américo Pereira Câmara
-#  October 2007
-#
 
 include "cairo_pragma.nim"
 
 type
-  PByte = cstring
-  TStatus* = enum
+  Status* = enum
     STATUS_SUCCESS = 0,
     STATUS_NO_MEMORY,
     STATUS_INVALID_RESTORE,
@@ -87,7 +84,7 @@ type
     STATUS_INVALID_WEIGHT
 
 
-  TOperator* = enum
+  Operator* = enum
     OPERATOR_CLEAR, OPERATOR_SOURCE, OPERATOR_OVER, OPERATOR_IN, OPERATOR_OUT,
     OPERATOR_ATOP, OPERATOR_DEST, OPERATOR_DEST_OVER, OPERATOR_DEST_IN,
     OPERATOR_DEST_OUT, OPERATOR_DEST_ATOP, OPERATOR_XOR, OPERATOR_ADD,
@@ -97,79 +94,61 @@ type
     OPERATOR_DIFFERENCE, OPERATOR_EXCLUSION, OPERATOR_HSL_HUE,
     OPERATOR_HSL_SATURATION, OPERATOR_HSL_COLOR, OPERATOR_HSL_LUMINOSITY
 
-  TAntialias* = enum
+  Antialias* = enum
     ANTIALIAS_DEFAULT, ANTIALIAS_NONE, ANTIALIAS_GRAY, ANTIALIAS_SUBPIXEL
-  TFillRule* = enum
+  FillRule* = enum
     FILL_RULE_WINDING, FILL_RULE_EVEN_ODD
-  TLineCap* = enum
+  LineCap* = enum
     LINE_CAP_BUTT, LINE_CAP_ROUND, LINE_CAP_SQUARE
-  TLineJoin* = enum
+  LineJoin* = enum
     LINE_JOIN_MITER, LINE_JOIN_ROUND, LINE_JOIN_BEVEL
-  TFontSlant* = enum
+  FontSlant* = enum
     FONT_SLANT_NORMAL, FONT_SLANT_ITALIC, FONT_SLANT_OBLIQUE
-  TFontWeight* = enum
+  FontWeight* = enum
     FONT_WEIGHT_NORMAL, FONT_WEIGHT_BOLD
-  TSubpixelOrder* = enum
+  SubpixelOrder* = enum
     SUBPIXEL_ORDER_DEFAULT, SUBPIXEL_ORDER_RGB, SUBPIXEL_ORDER_BGR,
     SUBPIXEL_ORDER_VRGB, SUBPIXEL_ORDER_VBGR
-  THintStyle* = enum
+  HintStyle* = enum
     HINT_STYLE_DEFAULT, HINT_STYLE_NONE, HINT_STYLE_SLIGHT, HINT_STYLE_MEDIUM,
     HINT_STYLE_FULL
-  THintMetrics* = enum
+  HintMetrics* = enum
     HINT_METRICS_DEFAULT, HINT_METRICS_OFF, HINT_METRICS_ON
-  TPathDataType* = enum
+  PathDataType* = enum
     PATH_MOVE_TO, PATH_LINE_TO, PATH_CURVE_TO, PATH_CLOSE_PATH
-  TContent* = enum
+  Content* = enum
     CONTENT_COLOR = 0x00001000, CONTENT_ALPHA = 0x00002000,
     CONTENT_COLOR_ALPHA = 0x00003000
-  TFormat* = enum
+  Format* = enum
     FORMAT_ARGB32, FORMAT_RGB24, FORMAT_A8, FORMAT_A1
-  TExtend* = enum
+  Extend* = enum
     EXTEND_NONE, EXTEND_REPEAT, EXTEND_REFLECT, EXTEND_PAD
-  TFilter* = enum
+  Filter* = enum
     FILTER_FAST, FILTER_GOOD, FILTER_BEST, FILTER_NEAREST, FILTER_BILINEAR,
     FILTER_GAUSSIAN
-  TFontType* = enum
+  FontType* = enum
     FONT_TYPE_TOY, FONT_TYPE_FT, FONT_TYPE_WIN32, FONT_TYPE_ATSUI
-  TPatternType* = enum
+  PatternType* = enum
     PATTERN_TYPE_SOLID, PATTERN_TYPE_SURFACE, PATTERN_TYPE_LINEAR,
     PATTERN_TYPE_RADIAL
-  TSurfaceType* = enum
+  SurfaceType* = enum
     SURFACE_TYPE_IMAGE, SURFACE_TYPE_PDF, SURFACE_TYPE_PS, SURFACE_TYPE_XLIB,
     SURFACE_TYPE_XCB, SURFACE_TYPE_GLITZ, SURFACE_TYPE_QUARTZ,
     SURFACE_TYPE_WIN32, SURFACE_TYPE_BEOS, SURFACE_TYPE_DIRECTFB,
     SURFACE_TYPE_SVG, SURFACE_TYPE_OS2
-  TSvgVersion* = enum
+  SvgVersion* = enum
     SVG_VERSION_1_1, SVG_VERSION_1_2
-  PSurface* = ptr TSurface
-  PPSurface* = ptr PSurface
-  PContext* = ptr TContext
-  PPattern* = ptr TPattern
-  PFontOptions* = ptr TFontOptions
-  PFontFace* = ptr TFontFace
-  PScaledFont* = ptr TScaledFont
-  PBool* = ptr TBool
-  TBool* = int32
-  PMatrix* = ptr TMatrix
-  PUserDataKey* = ptr TUserDataKey
-  PGlyph* = ptr TGlyph
-  PTextExtents* = ptr TTextExtents
-  PFontExtents* = ptr TFontExtents
-  PPathDataType* = ptr TPathDataType
-  PPathData* = ptr TPathData
-  PPath* = ptr TPath
-  PRectangle* = ptr TRectangle
-  PRectangleList* = ptr TRectangleList
-  TDestroyFunc* = proc (data: pointer){.cdecl.}
-  TWriteFunc* = proc (closure: pointer, data: PByte, len: int32): TStatus{.cdecl.}
-  TReadFunc* = proc (closure: pointer, data: PByte, len: int32): TStatus{.cdecl.}
-  TContext*{.final.} = object        #OPAQUE
-  TSurface*{.final.} = object  #OPAQUE
-  TPattern*{.final.} = object  #OPAQUE
-  TScaledFont*{.final.} = object  #OPAQUE
-  TFontFace*{.final.} = object  #OPAQUE
-  TFontOptions*{.final.} = object  #OPAQUE
-  TMatrix*{.final.} = object
+  Bool* = int32
+  DestroyFunc* = proc (data: pointer){.cdecl.}
+  WriteFunc* = proc (closure: pointer, data: cstring, len: int32): Status{.cdecl.}
+  ReadFunc* = proc (closure: pointer, data: cstring, len: int32): Status{.cdecl.}
+  Context*{.final.} = object
+  Surface*{.final.} = object
+  Pattern*{.final.} = object
+  ScaledFont*{.final.} = object
+  FontFace*{.final.} = object
+  FontOptions*{.final.} = object
+  Matrix*{.final.} = object
     xx*: float64
     yx*: float64
     xy*: float64
@@ -177,299 +156,299 @@ type
     x0*: float64
     y0*: float64
 
-  TUserDataKey*{.final.} = object
+  UserDataKey*{.final.} = object
     unused*: int32
 
-  TGlyph*{.final.} = object
+  Glyph*{.final.} = object
     index*: int32
     x*: float64
     y*: float64
 
-  TTextExtents*{.final.} = object
-    x_bearing*: float64
-    y_bearing*: float64
+  TextExtents*{.final.} = object
+    xBearing* {.importc: "x_bearing".}: float64
+    yBearing* {.importc: "y_bearing".}: float64
     width*: float64
     height*: float64
-    x_advance*: float64
-    y_advance*: float64
+    xAdvance* {.importc: "x_advance".}: float64
+    yAdvance* {.importc: "y_advance".}: float64
 
-  TFontExtents*{.final.} = object
+  FontExtents*{.final.} = object
     ascent*: float64
     descent*: float64
     height*: float64
-    max_x_advance*: float64
-    max_y_advance*: float64
+    maxXAdvance* {.importc: "max_x_advance".}: float64
+    maxYAadvance* {.importc: "max_y_advance".}: float64
 
-  TPathData*{.final.} = object  #* _type : TCairoPathDataType;
+  PathData*{.final.} = object  #* _type : TCairoPathDataType;
                                 #       length : LongInt;
                                 #    end
     x*: float64
     y*: float64
 
-  TPath*{.final.} = object
-    status*: TStatus
-    data*: PPathData
-    num_data*: int32
+  Path*{.final.} = object
+    status*: Status
+    data*: ptr PathData
+    numData* {.importc: "num_data".}: int32
 
-  TRectangle*{.final.} = object
+  Rectangle*{.final.} = object
     x*, y*, width*, height*: float64
 
-  TRectangleList*{.final.} = object
-    status*: TStatus
-    rectangles*: PRectangle
-    num_rectangles*: int32
+  RectangleList*{.final.} = object
+    status*: Status
+    rectangles*: ptr Rectangle
+    numRectangles* {.importc: "num_rectangles".}: int32
 
 {.push dynlib: LIB_CAIRO, cdecl.}
 
 proc version*(): int32 {.importc: "cairo_version".}
 proc versionString*(): cstring {.importc: "cairo_version_string".}
-proc create*(target: PSurface): PContext {.importc: "cairo_create".}
-proc reference*(cr: PContext): PContext {.importc: "cairo_reference".}
-proc destroy*(cr: PContext) {.importc: "cairo_destroy".}
-proc getReferenceCount*(cr: PContext): int32 {.importc: "cairo_get_reference_count".}
-proc getUserData*(cr: PContext, key: PUserDataKey): pointer {.importc: "cairo_get_user_data".}
-proc setUserData*(cr: PContext, key: PUserDataKey, user_data: pointer, destroy: TDestroyFunc): TStatus {.importc: "cairo_set_user_data".}
-proc save*(cr: PContext) {.importc: "cairo_save".}
-proc restore*(cr: PContext) {.importc: "cairo_restore".}
-proc pushGroup*(cr: PContext) {.importc: "cairo_push_group".}
-proc pushGroupWithContent*(cr: PContext, content: TContent) {.importc: "cairo_push_group_with_content".}
-proc popGroup*(cr: PContext): PPattern {.importc: "cairo_pop_group".}
-proc popGroupToSource*(cr: PContext) {.importc: "cairo_pop_group_to_source".}
+proc create*(target: ptr Surface): ptr Context {.importc: "cairo_create".}
+proc reference*(cr: ptr Context): ptr Context {.importc: "cairo_reference".}
+proc destroy*(cr: ptr Context) {.importc: "cairo_destroy".}
+proc getReferenceCount*(cr: ptr Context): int32 {.importc: "cairo_get_reference_count".}
+proc getUserData*(cr: ptr Context, key: ptr UserDataKey): pointer {.importc: "cairo_get_user_data".}
+proc setUserData*(cr: ptr Context, key: ptr UserDataKey, user_data: pointer, destroy: DestroyFunc): Status {.importc: "cairo_set_user_data".}
+proc save*(cr: ptr Context) {.importc: "cairo_save".}
+proc restore*(cr: ptr Context) {.importc: "cairo_restore".}
+proc pushGroup*(cr: ptr Context) {.importc: "cairo_push_group".}
+proc pushGroupWithContent*(cr: ptr Context, content: Content) {.importc: "cairo_push_group_with_content".}
+proc popGroup*(cr: ptr Context): ptr Pattern {.importc: "cairo_pop_group".}
+proc popGroupToSource*(cr: ptr Context) {.importc: "cairo_pop_group_to_source".}
 # Modify state
-proc setOperator*(cr: PContext, op: TOperator) {.importc: "cairo_set_operator".}
-proc setSource*(cr: PContext, source: PPattern) {.importc: "cairo_set_source".}
-proc setSourceRgb*(cr: PContext, red, green, blue: float64) {.importc: "cairo_set_source_rgb".}
-proc setSourceRgba*(cr: PContext, red, green, blue, alpha: float64) {.importc: "cairo_set_source_rgba".}
-proc setSource*(cr: PContext, surface: PSurface, x, y: float64) {.importc: "cairo_set_source_surface".}
-proc setTolerance*(cr: PContext, tolerance: float64) {.importc: "cairo_set_tolerance".}
-proc setAntialias*(cr: PContext, antialias: TAntialias) {.importc: "cairo_set_antialias".}
-proc setFillRule*(cr: PContext, fill_rule: TFillRule) {.importc: "cairo_set_fill_rule".}
-proc setLineWidth*(cr: PContext, width: float64) {.importc: "cairo_set_line_width".}
-proc setLineCap*(cr: PContext, line_cap: TLineCap) {.importc: "cairo_set_line_cap".}
-proc setLineJoin*(cr: PContext, line_join: TLineJoin) {.importc: "cairo_set_line_join".}
-proc setDash*(cr: PContext, dashes: openarray[float64], offset: float64) {.importc: "cairo_set_dash".}
-proc setMiterLimit*(cr: PContext, limit: float64) {.importc: "cairo_set_miter_limit".}
-proc translate*(cr: PContext, tx, ty: float64) {.importc: "cairo_translate".}
-proc scale*(cr: PContext, sx, sy: float64) {.importc: "cairo_scale".}
-proc rotate*(cr: PContext, angle: float64) {.importc: "cairo_rotate".}
-proc transform*(cr: PContext, matrix: PMatrix) {.importc: "cairo_transform".}
-proc setMatrix*(cr: PContext, matrix: PMatrix) {.importc: "cairo_set_matrix".}
-proc identityMatrix*(cr: PContext) {.importc: "cairo_identity_matrix".}
-proc userToDevice*(cr: PContext, x, y: var float64) {.importc: "cairo_user_to_device".}
-proc userToDeviceDistance*(cr: PContext, dx, dy: var float64) {.importc: "cairo_user_to_device_distance".}
-proc deviceToUser*(cr: PContext, x, y: var float64) {.importc: "cairo_device_to_user".}
-proc deviceToUserDistance*(cr: PContext, dx, dy: var float64) {.importc: "cairo_device_to_user_distance".}
+proc setOperator*(cr: ptr Context, op: Operator) {.importc: "cairo_set_operator".}
+proc setSource*(cr: ptr Context, source: ptr Pattern) {.importc: "cairo_set_source".}
+proc setSourceRgb*(cr: ptr Context, red, green, blue: float64) {.importc: "cairo_set_source_rgb".}
+proc setSourceRgba*(cr: ptr Context, red, green, blue, alpha: float64) {.importc: "cairo_set_source_rgba".}
+proc setSource*(cr: ptr Context, surface: ptr Surface, x, y: float64) {.importc: "cairo_set_source_surface".}
+proc setTolerance*(cr: ptr Context, tolerance: float64) {.importc: "cairo_set_tolerance".}
+proc setAntialias*(cr: ptr Context, antialias: Antialias) {.importc: "cairo_set_antialias".}
+proc setFillRule*(cr: ptr Context, fill_rule: FillRule) {.importc: "cairo_set_fill_rule".}
+proc setLineWidth*(cr: ptr Context, width: float64) {.importc: "cairo_set_line_width".}
+proc setLineCap*(cr: ptr Context, line_cap: LineCap) {.importc: "cairo_set_line_cap".}
+proc setLineJoin*(cr: ptr Context, line_join: LineJoin) {.importc: "cairo_set_line_join".}
+proc setDash*(cr: ptr Context, dashes: openarray[float64], offset: float64) {.importc: "cairo_set_dash".}
+proc setMiterLimit*(cr: ptr Context, limit: float64) {.importc: "cairo_set_miter_limit".}
+proc translate*(cr: ptr Context, tx, ty: float64) {.importc: "cairo_translate".}
+proc scale*(cr: ptr Context, sx, sy: float64) {.importc: "cairo_scale".}
+proc rotate*(cr: ptr Context, angle: float64) {.importc: "cairo_rotate".}
+proc transform*(cr: ptr Context, matrix: ptr Matrix) {.importc: "cairo_transform".}
+proc setMatrix*(cr: ptr Context, matrix: ptr Matrix) {.importc: "cairo_set_matrix".}
+proc identityMatrix*(cr: ptr Context) {.importc: "cairo_identity_matrix".}
+proc userToDevice*(cr: ptr Context, x, y: var float64) {.importc: "cairo_user_to_device".}
+proc userToDeviceDistance*(cr: ptr Context, dx, dy: var float64) {.importc: "cairo_user_to_device_distance".}
+proc deviceToUser*(cr: ptr Context, x, y: var float64) {.importc: "cairo_device_to_user".}
+proc deviceToUserDistance*(cr: ptr Context, dx, dy: var float64) {.importc: "cairo_device_to_user_distance".}
 # Path creation functions
-proc newPath*(cr: PContext) {.importc: "cairo_new_path".}
-proc moveTo*(cr: PContext, x, y: float64) {.importc: "cairo_move_to".}
-proc newSubPath*(cr: PContext) {.importc: "cairo_new_sub_path".}
-proc lineTo*(cr: PContext, x, y: float64) {.importc: "cairo_line_to".}
-proc curveTo*(cr: PContext, x1, y1, x2, y2, x3, y3: float64) {.importc: "cairo_curve_to".}
-proc arc*(cr: PContext, xc, yc, radius, angle1, angle2: float64) {.importc: "cairo_arc".}
-proc arcNegative*(cr: PContext, xc, yc, radius, angle1, angle2: float64) {.importc: "cairo_arc_negative".}
-proc relMoveTo*(cr: PContext, dx, dy: float64) {.importc: "cairo_rel_move_to".}
-proc relLineTo*(cr: PContext, dx, dy: float64) {.importc: "cairo_rel_line_to".}
-proc relCurveTo*(cr: PContext, dx1, dy1, dx2, dy2, dx3, dy3: float64) {.importc: "cairo_rel_curve_to".}
-proc rectangle*(cr: PContext, x, y, width, height: float64) {.importc: "cairo_rectangle".}
-proc closePath*(cr: PContext) {.importc: "cairo_close_path".}
+proc newPath*(cr: ptr Context) {.importc: "cairo_new_path".}
+proc moveTo*(cr: ptr Context, x, y: float64) {.importc: "cairo_move_to".}
+proc newSubPath*(cr: ptr Context) {.importc: "cairo_new_sub_path".}
+proc lineTo*(cr: ptr Context, x, y: float64) {.importc: "cairo_line_to".}
+proc curveTo*(cr: ptr Context, x1, y1, x2, y2, x3, y3: float64) {.importc: "cairo_curve_to".}
+proc arc*(cr: ptr Context, xc, yc, radius, angle1, angle2: float64) {.importc: "cairo_arc".}
+proc arcNegative*(cr: ptr Context, xc, yc, radius, angle1, angle2: float64) {.importc: "cairo_arc_negative".}
+proc relMoveTo*(cr: ptr Context, dx, dy: float64) {.importc: "cairo_rel_move_to".}
+proc relLineTo*(cr: ptr Context, dx, dy: float64) {.importc: "cairo_rel_line_to".}
+proc relCurveTo*(cr: ptr Context, dx1, dy1, dx2, dy2, dx3, dy3: float64) {.importc: "cairo_rel_curve_to".}
+proc rectangle*(cr: ptr Context, x, y, width, height: float64) {.importc: "cairo_rectangle".}
+proc closePath*(cr: ptr Context) {.importc: "cairo_close_path".}
 # Painting functions
-proc paint*(cr: PContext) {.importc: "cairo_paint".}
-proc paintWithAlpha*(cr: PContext, alpha: float64) {.importc: "cairo_paint_with_alpha".}
-proc mask*(cr: PContext, pattern: PPattern) {.importc: "cairo_mask".}
-proc mask*(cr: PContext, surface: PSurface, surface_x, surface_y: float64){. cdecl, importc: "cairo_mask_surface".}
-proc stroke*(cr: PContext) {.importc: "cairo_stroke".}
-proc strokePreserve*(cr: PContext) {.importc: "cairo_stroke_preserve".}
-proc fill*(cr: PContext) {.importc: "cairo_fill".}
-proc fillPreserve*(cr: PContext) {.importc: "cairo_fill_preserve".}
-proc copyPage*(cr: PContext) {.importc: "cairo_copy_page".}
-proc showPage*(cr: PContext) {.importc: "cairo_show_page".}
+proc paint*(cr: ptr Context) {.importc: "cairo_paint".}
+proc paintWithAlpha*(cr: ptr Context, alpha: float64) {.importc: "cairo_paint_with_alpha".}
+proc mask*(cr: ptr Context, pattern: ptr Pattern) {.importc: "cairo_mask".}
+proc mask*(cr: ptr Context, surface: ptr Surface, surface_x, surface_y: float64){. cdecl, importc: "cairo_mask_surface".}
+proc stroke*(cr: ptr Context) {.importc: "cairo_stroke".}
+proc strokePreserve*(cr: ptr Context) {.importc: "cairo_stroke_preserve".}
+proc fill*(cr: ptr Context) {.importc: "cairo_fill".}
+proc fillPreserve*(cr: ptr Context) {.importc: "cairo_fill_preserve".}
+proc copyPage*(cr: ptr Context) {.importc: "cairo_copy_page".}
+proc showPage*(cr: ptr Context) {.importc: "cairo_show_page".}
 # Insideness testing
-proc inStroke*(cr: PContext, x, y: float64): TBool {.importc: "cairo_in_stroke".}
-proc inFill*(cr: PContext, x, y: float64): TBool {.importc: "cairo_in_fill".}
+proc inStroke*(cr: ptr Context, x, y: float64): Bool {.importc: "cairo_in_stroke".}
+proc inFill*(cr: ptr Context, x, y: float64): Bool {.importc: "cairo_in_fill".}
 # Rectangular extents
-proc strokeExtents*(cr: PContext, x1, y1, x2, y2: var float64) {.importc: "cairo_stroke_extents".}
-proc fillExtents*(cr: PContext, x1, y1, x2, y2: var float64) {.importc: "cairo_fill_extents".}
+proc strokeExtents*(cr: ptr Context, x1, y1, x2, y2: var float64) {.importc: "cairo_stroke_extents".}
+proc fillExtents*(cr: ptr Context, x1, y1, x2, y2: var float64) {.importc: "cairo_fill_extents".}
 # Clipping
-proc resetClip*(cr: PContext) {.importc: "cairo_reset_clip".}
-proc clip*(cr: PContext) {.importc: "cairo_clip".}
-proc clipPreserve*(cr: PContext) {.importc: "cairo_clip_preserve".}
-proc clipExtents*(cr: PContext, x1, y1, x2, y2: var float64) {.importc: "cairo_clip_extents".}
-proc copyClipRectangleList*(cr: PContext): PRectangleList {.importc: "cairo_copy_clip_rectangle_list".}
-proc rectangleListDestroy*(rectangle_list: PRectangleList) {.importc: "cairo_rectangle_list_destroy".}
+proc resetClip*(cr: ptr Context) {.importc: "cairo_reset_clip".}
+proc clip*(cr: ptr Context) {.importc: "cairo_clip".}
+proc clipPreserve*(cr: ptr Context) {.importc: "cairo_clip_preserve".}
+proc clipExtents*(cr: ptr Context, x1, y1, x2, y2: var float64) {.importc: "cairo_clip_extents".}
+proc copyClipRectangleList*(cr: ptr Context): ptr RectangleList {.importc: "cairo_copy_clip_rectangle_list".}
+proc rectangleListDestroy*(rectangle_list: ptr RectangleList) {.importc: "cairo_rectangle_list_destroy".}
 # Font/Text functions
-proc fontOptionsCreate*(): PFontOptions {.importc: "cairo_font_options_create".}
-proc copy*(original: PFontOptions): PFontOptions {.importc: "cairo_font_options_copy".}
-proc destroy*(options: PFontOptions) {.importc: "cairo_font_options_destroy".}
-proc status*(options: PFontOptions): TStatus {.importc: "cairo_font_options_status".}
-proc merge*(options, other: PFontOptions) {.importc: "cairo_font_options_merge".}
-proc equal*(options, other: PFontOptions): TBool {.importc: "cairo_font_options_equal".}
-proc hash*(options: PFontOptions): int32 {.importc: "cairo_font_options_hash".}
-proc setAntialias*(options: PFontOptions, antialias: TAntialias){. cdecl, importc: "cairo_font_options_set_antialias".}
-proc getAntialias*(options: PFontOptions): TAntialias {.importc: "cairo_font_options_get_antialias".}
-proc setSubpixelOrder*(options: PFontOptions, subpixel_order: TSubpixelOrder) {.importc: "cairo_font_options_set_subpixel_order".}
-proc getSubpixelOrder*(options: PFontOptions): TSubpixelOrder{. cdecl, importc: "cairo_font_options_get_subpixel_order".}
-proc setHintStyle*(options: PFontOptions, hint_style: THintStyle){. cdecl, importc: "cairo_font_options_set_hint_style".}
-proc getHintStyle*(options: PFontOptions): THintStyle {.importc: "cairo_font_options_get_hint_style".}
-proc setHintMetrics*(options: PFontOptions, hint_metrics: THintMetrics) {.importc: "cairo_font_options_set_hint_metrics".}
-proc getHintMetrics*(options: PFontOptions): THintMetrics {.importc: "cairo_font_options_get_hint_metrics".}
+proc fontOptionsCreate*(): ptr FontOptions {.importc: "cairo_font_options_create".}
+proc copy*(original: ptr FontOptions): ptr FontOptions {.importc: "cairo_font_options_copy".}
+proc destroy*(options: ptr FontOptions) {.importc: "cairo_font_options_destroy".}
+proc status*(options: ptr FontOptions): Status {.importc: "cairo_font_options_status".}
+proc merge*(options, other: ptr FontOptions) {.importc: "cairo_font_options_merge".}
+proc equal*(options, other: ptr FontOptions): Bool {.importc: "cairo_font_options_equal".}
+proc hash*(options: ptr FontOptions): int32 {.importc: "cairo_font_options_hash".}
+proc setAntialias*(options: ptr FontOptions, antialias: Antialias){. cdecl, importc: "cairo_font_options_set_antialias".}
+proc getAntialias*(options: ptr FontOptions): Antialias {.importc: "cairo_font_options_get_antialias".}
+proc setSubpixelOrder*(options: ptr FontOptions, subpixel_order: SubpixelOrder) {.importc: "cairo_font_options_set_subpixel_order".}
+proc getSubpixelOrder*(options: ptr FontOptions): SubpixelOrder{. cdecl, importc: "cairo_font_options_get_subpixel_order".}
+proc setHintStyle*(options: ptr FontOptions, hint_style: HintStyle){. cdecl, importc: "cairo_font_options_set_hint_style".}
+proc getHintStyle*(options: ptr FontOptions): HintStyle {.importc: "cairo_font_options_get_hint_style".}
+proc setHintMetrics*(options: ptr FontOptions, hint_metrics: HintMetrics) {.importc: "cairo_font_options_set_hint_metrics".}
+proc getHintMetrics*(options: ptr FontOptions): HintMetrics {.importc: "cairo_font_options_get_hint_metrics".}
 # This interface is for dealing with text as text, not caring about the
   #   font object inside the the TCairo.
-proc selectFontFace*(cr: PContext, family: cstring, slant: TFontSlant, weight: TFontWeight) {.importc: "cairo_select_font_face".}
-proc setFontSize*(cr: PContext, size: float64) {.importc: "cairo_set_font_size".}
-proc setFontMatrix*(cr: PContext, matrix: PMatrix) {.importc: "cairo_set_font_matrix".}
-proc getFontMatrix*(cr: PContext, matrix: PMatrix) {.importc: "cairo_get_font_matrix".}
-proc setFontOptions*(cr: PContext, options: PFontOptions) {.importc: "cairo_set_font_options".}
-proc getFontOptions*(cr: PContext, options: PFontOptions) {.importc: "cairo_get_font_options".}
-proc setFontFace*(cr: PContext, font_face: PFontFace) {.importc: "cairo_set_font_face".}
-proc getFontFace*(cr: PContext): PFontFace {.importc: "cairo_get_font_face".}
-proc setScaledFont*(cr: PContext, scaled_font: PScaledFont) {.importc: "cairo_set_scaled_font".}
-proc getScaledFont*(cr: PContext): PScaledFont {.importc: "cairo_get_scaled_font".}
-proc showText*(cr: PContext, utf8: cstring) {.importc: "cairo_show_text".}
-proc showGlyphs*(cr: PContext, glyphs: PGlyph, num_glyphs: int32) {.importc: "cairo_show_glyphs".}
-proc textPath*(cr: PContext, utf8: cstring) {.importc: "cairo_text_path".}
-proc glyphPath*(cr: PContext, glyphs: PGlyph, num_glyphs: int32) {.importc: "cairo_glyph_path".}
-proc textExtents*(cr: PContext, utf8: cstring, extents: PTextExtents) {.importc: "cairo_text_extents".}
-proc glyphExtents*(cr: PContext, glyphs: PGlyph, num_glyphs: int32, extents: PTextExtents) {.importc: "cairo_glyph_extents".}
-proc fontExtents*(cr: PContext, extents: PFontExtents) {.importc: "cairo_font_extents".}
+proc selectFontFace*(cr: ptr Context, family: cstring, slant: FontSlant, weight: FontWeight) {.importc: "cairo_select_font_face".}
+proc setFontSize*(cr: ptr Context, size: float64) {.importc: "cairo_set_font_size".}
+proc setFontMatrix*(cr: ptr Context, matrix: ptr Matrix) {.importc: "cairo_set_font_matrix".}
+proc getFontMatrix*(cr: ptr Context, matrix: ptr Matrix) {.importc: "cairo_get_font_matrix".}
+proc setFontOptions*(cr: ptr Context, options: ptr FontOptions) {.importc: "cairo_set_font_options".}
+proc getFontOptions*(cr: ptr Context, options: ptr FontOptions) {.importc: "cairo_get_font_options".}
+proc setFontFace*(cr: ptr Context, font_face: ptr FontFace) {.importc: "cairo_set_font_face".}
+proc getFontFace*(cr: ptr Context): ptr FontFace {.importc: "cairo_get_font_face".}
+proc setScaledFont*(cr: ptr Context, scaled_font: ptr ScaledFont) {.importc: "cairo_set_scaled_font".}
+proc getScaledFont*(cr: ptr Context): ptr ScaledFont {.importc: "cairo_get_scaled_font".}
+proc showText*(cr: ptr Context, utf8: cstring) {.importc: "cairo_show_text".}
+proc showGlyphs*(cr: ptr Context, glyphs: ptr Glyph, num_glyphs: int32) {.importc: "cairo_show_glyphs".}
+proc textPath*(cr: ptr Context, utf8: cstring) {.importc: "cairo_text_path".}
+proc glyphPath*(cr: ptr Context, glyphs: ptr Glyph, num_glyphs: int32) {.importc: "cairo_glyph_path".}
+proc textExtents*(cr: ptr Context, utf8: cstring, extents: ptr TextExtents) {.importc: "cairo_text_extents".}
+proc glyphExtents*(cr: ptr Context, glyphs: ptr Glyph, num_glyphs: int32, extents: ptr TextExtents) {.importc: "cairo_glyph_extents".}
+proc fontExtents*(cr: ptr Context, extents: ptr FontExtents) {.importc: "cairo_font_extents".}
 # Generic identifier for a font style
-proc reference*(font_face: PFontFace): PFontFace {.importc: "cairo_font_face_reference".}
-proc destroy*(font_face: PFontFace) {.importc: "cairo_font_face_destroy".}
-proc getReferenceCount*(font_face: PFontFace): int32 {.importc: "cairo_font_face_get_reference_count".}
-proc status*(font_face: PFontFace): TStatus {.importc: "cairo_font_face_status".}
-proc getType*(font_face: PFontFace): TFontType {.importc: "cairo_font_face_get_type".}
-proc getUserData*(font_face: PFontFace, key: PUserDataKey): pointer{. cdecl, importc: "cairo_font_face_get_user_data".}
-proc setUserData*(font_face: PFontFace, key: PUserDataKey, user_data: pointer, destroy: TDestroyFunc): TStatus{. cdecl, importc: "cairo_font_face_set_user_data".}
+proc reference*(font_face: ptr FontFace): ptr FontFace {.importc: "cairo_font_face_reference".}
+proc destroy*(font_face: ptr FontFace) {.importc: "cairo_font_face_destroy".}
+proc getReferenceCount*(font_face: ptr FontFace): int32 {.importc: "cairo_font_face_get_reference_count".}
+proc status*(font_face: ptr FontFace): Status {.importc: "cairo_font_face_status".}
+proc getType*(font_face: ptr FontFace): FontType {.importc: "cairo_font_face_get_type".}
+proc getUserData*(font_face: ptr FontFace, key: ptr UserDataKey): pointer{. cdecl, importc: "cairo_font_face_get_user_data".}
+proc setUserData*(font_face: ptr FontFace, key: ptr UserDataKey, user_data: pointer, destroy: DestroyFunc): Status{. cdecl, importc: "cairo_font_face_set_user_data".}
 # Portable interface to general font features
-proc scaledFontCreate*(font_face: PFontFace, font_matrix: PMatrix, ctm: PMatrix, options: PFontOptions): PScaledFont{. cdecl, importc: "cairo_scaled_font_create".}
-proc reference*(scaled_font: PScaledFont): PScaledFont {.importc: "cairo_scaled_font_reference".}
-proc destroy*(scaled_font: PScaledFont) {.importc: "cairo_scaled_font_destroy".}
-proc getReferenceCount*(scaled_font: PScaledFont): int32 {.importc: "cairo_scaled_font_get_reference_count".}
-proc status*(scaled_font: PScaledFont): TStatus {.importc: "cairo_scaled_font_status".}
-proc getType*(scaled_font: PScaledFont): TFontType {.importc: "cairo_scaled_font_get_type".}
-proc getUserData*(scaled_font: PScaledFont, key: PUserDataKey): pointer{. cdecl, importc: "cairo_scaled_font_get_user_data".}
-proc setUserData*(scaled_font: PScaledFont, key: PUserDataKey, user_data: pointer, destroy: TDestroyFunc): TStatus{. cdecl, importc: "cairo_scaled_font_set_user_data".}
-proc extents*(scaled_font: PScaledFont, extents: PFontExtents){. cdecl, importc: "cairo_scaled_font_extents".}
-proc textExtents*(scaled_font: PScaledFont, utf8: cstring, extents: PTextExtents) {.importc: "cairo_scaled_font_text_extents".}
-proc glyphExtents*(scaled_font: PScaledFont, glyphs: PGlyph, num_glyphs: int32, extents: PTextExtents){. cdecl, importc: "cairo_scaled_font_glyph_extents".}
-proc getFontFace*(scaled_font: PScaledFont): PFontFace {.importc: "cairo_scaled_font_get_font_face".}
-proc getFontMatrix*(scaled_font: PScaledFont, font_matrix: PMatrix){. cdecl, importc: "cairo_scaled_font_get_font_matrix".}
-proc getCtm*(scaled_font: PScaledFont, ctm: PMatrix) {.importc: "cairo_scaled_font_get_ctm".}
-proc getFontOptions*(scaled_font: PScaledFont, options: PFontOptions) {.importc: "cairo_scaled_font_get_font_options".}
+proc scaledFontCreate*(font_face: ptr FontFace, font_matrix: ptr Matrix, ctm: ptr Matrix, options: ptr FontOptions): ptr ScaledFont{. cdecl, importc: "cairo_scaled_font_create".}
+proc reference*(scaled_font: ptr ScaledFont): ptr ScaledFont {.importc: "cairo_scaled_font_reference".}
+proc destroy*(scaled_font: ptr ScaledFont) {.importc: "cairo_scaled_font_destroy".}
+proc getReferenceCount*(scaled_font: ptr ScaledFont): int32 {.importc: "cairo_scaled_font_get_reference_count".}
+proc status*(scaled_font: ptr ScaledFont): Status {.importc: "cairo_scaled_font_status".}
+proc getType*(scaled_font: ptr ScaledFont): FontType {.importc: "cairo_scaled_font_get_type".}
+proc getUserData*(scaled_font: ptr ScaledFont, key: ptr UserDataKey): pointer{. cdecl, importc: "cairo_scaled_font_get_user_data".}
+proc setUserData*(scaled_font: ptr ScaledFont, key: ptr UserDataKey, user_data: pointer, destroy: DestroyFunc): Status{. cdecl, importc: "cairo_scaled_font_set_user_data".}
+proc extents*(scaled_font: ptr ScaledFont, extents: ptr FontExtents){. cdecl, importc: "cairo_scaled_font_extents".}
+proc textExtents*(scaled_font: ptr ScaledFont, utf8: cstring, extents: ptr TextExtents) {.importc: "cairo_scaled_font_text_extents".}
+proc glyphExtents*(scaled_font: ptr ScaledFont, glyphs: ptr Glyph, num_glyphs: int32, extents: ptr TextExtents){. cdecl, importc: "cairo_scaled_font_glyph_extents".}
+proc getFontFace*(scaled_font: ptr ScaledFont): ptr FontFace {.importc: "cairo_scaled_font_get_font_face".}
+proc getFontMatrix*(scaled_font: ptr ScaledFont, font_matrix: ptr Matrix){. cdecl, importc: "cairo_scaled_font_get_font_matrix".}
+proc getCtm*(scaled_font: ptr ScaledFont, ctm: ptr Matrix) {.importc: "cairo_scaled_font_get_ctm".}
+proc getFontOptions*(scaled_font: ptr ScaledFont, options: ptr FontOptions) {.importc: "cairo_scaled_font_get_font_options".}
 # Query functions
-proc getOperator*(cr: PContext): TOperator {.importc: "cairo_get_operator".}
-proc getSource*(cr: PContext): PPattern {.importc: "cairo_get_source".}
-proc getTolerance*(cr: PContext): float64 {.importc: "cairo_get_tolerance".}
-proc getAntialias*(cr: PContext): TAntialias {.importc: "cairo_get_antialias".}
-proc getCurrentPoint*(cr: PContext, x, y: var float64) {.importc: "cairo_get_current_point".}
-proc getFillRule*(cr: PContext): TFillRule {.importc: "cairo_get_fill_rule".}
-proc getLineWidth*(cr: PContext): float64 {.importc: "cairo_get_line_width".}
-proc getLineCap*(cr: PContext): TLineCap {.importc: "cairo_get_line_cap".}
-proc getLineJoin*(cr: PContext): TLineJoin {.importc: "cairo_get_line_join".}
-proc getMiterLimit*(cr: PContext): float64 {.importc: "cairo_get_miter_limit".}
-proc getDashCount*(cr: PContext): int32 {.importc: "cairo_get_dash_count".}
-proc getDash*(cr: PContext, dashes, offset: var float64) {.importc: "cairo_get_dash".}
-proc getMatrix*(cr: PContext, matrix: PMatrix) {.importc: "cairo_get_matrix".}
-proc getTarget*(cr: PContext): PSurface {.importc: "cairo_get_target".}
-proc getGroupTarget*(cr: PContext): PSurface {.importc: "cairo_get_group_target".}
-proc copyPath*(cr: PContext): PPath {.importc: "cairo_copy_path".}
-proc copyPathFlat*(cr: PContext): PPath {.importc: "cairo_copy_path_flat".}
-proc appendPath*(cr: PContext, path: PPath) {.importc: "cairo_append_path".}
-proc destroy*(path: PPath) {.importc: "cairo_path_destroy".}
+proc getOperator*(cr: ptr Context): Operator {.importc: "cairo_get_operator".}
+proc getSource*(cr: ptr Context): ptr Pattern {.importc: "cairo_get_source".}
+proc getTolerance*(cr: ptr Context): float64 {.importc: "cairo_get_tolerance".}
+proc getAntialias*(cr: ptr Context): Antialias {.importc: "cairo_get_antialias".}
+proc getCurrentPoint*(cr: ptr Context, x, y: var float64) {.importc: "cairo_get_current_point".}
+proc getFillRule*(cr: ptr Context): FillRule {.importc: "cairo_get_fill_rule".}
+proc getLineWidth*(cr: ptr Context): float64 {.importc: "cairo_get_line_width".}
+proc getLineCap*(cr: ptr Context): LineCap {.importc: "cairo_get_line_cap".}
+proc getLineJoin*(cr: ptr Context): LineJoin {.importc: "cairo_get_line_join".}
+proc getMiterLimit*(cr: ptr Context): float64 {.importc: "cairo_get_miter_limit".}
+proc getDashCount*(cr: ptr Context): int32 {.importc: "cairo_get_dash_count".}
+proc getDash*(cr: ptr Context, dashes, offset: var float64) {.importc: "cairo_get_dash".}
+proc getMatrix*(cr: ptr Context, matrix: ptr Matrix) {.importc: "cairo_get_matrix".}
+proc getTarget*(cr: ptr Context): ptr Surface {.importc: "cairo_get_target".}
+proc getGroupTarget*(cr: ptr Context): ptr Surface {.importc: "cairo_get_group_target".}
+proc copyPath*(cr: ptr Context): ptr Path {.importc: "cairo_copy_path".}
+proc copyPathFlat*(cr: ptr Context): ptr Path {.importc: "cairo_copy_path_flat".}
+proc appendPath*(cr: ptr Context, path: ptr Path) {.importc: "cairo_append_path".}
+proc destroy*(path: ptr Path) {.importc: "cairo_path_destroy".}
 # Error status queries
-proc status*(cr: PContext): TStatus {.importc: "cairo_status".}
-proc statusToString*(status: TStatus): cstring {.importc: "cairo_status_to_string".}
+proc status*(cr: ptr Context): Status {.importc: "cairo_status".}
+proc statusToString*(status: Status): cstring {.importc: "cairo_status_to_string".}
 # Surface manipulation
-proc surfaceCreateSimilar*(other: PSurface, content: TContent, width, height: int32): PSurface {.importc: "cairo_surface_create_similar".}
-proc reference*(surface: PSurface): PSurface {.importc: "cairo_surface_reference".}
-proc finish*(surface: PSurface) {.importc: "cairo_surface_finish".}
-proc destroy*(surface: PSurface) {.importc: "cairo_surface_destroy".}
-proc getReferenceCount*(surface: PSurface): int32 {.importc: "cairo_surface_get_reference_count".}
-proc status*(surface: PSurface): TStatus {.importc: "cairo_surface_status".}
-proc getType*(surface: PSurface): TSurfaceType {.importc: "cairo_surface_get_type".}
-proc getContent*(surface: PSurface): TContent {.importc: "cairo_surface_get_content".}
-proc writeToPng*(surface: PSurface, filename: cstring): TStatus{. cdecl, importc: "cairo_surface_write_to_png".}
-proc writeToPng*(surface: PSurface, write_func: TWriteFunc, closure: pointer): TStatus {.importc: "cairo_surface_write_to_png_stream".}
-proc getUserData*(surface: PSurface, key: PUserDataKey): pointer{. cdecl, importc: "cairo_surface_get_user_data".}
-proc setUserData*(surface: PSurface, key: PUserDataKey, user_data: pointer, destroy: TDestroyFunc): TStatus{. cdecl, importc: "cairo_surface_set_user_data".}
-proc getFontOptions*(surface: PSurface, options: PFontOptions) {.importc: "cairo_surface_get_font_options".}
-proc flush*(surface: PSurface) {.importc: "cairo_surface_flush".}
-proc markDirty*(surface: PSurface) {.importc: "cairo_surface_mark_dirty".}
-proc markDirtyRectangle*(surface: PSurface, x, y, width, height: int32){. cdecl, importc: "cairo_surface_mark_dirty_rectangle".}
-proc setDeviceOffset*(surface: PSurface, x_offset, y_offset: float64){. cdecl, importc: "cairo_surface_set_device_offset".}
-proc getDeviceOffset*(surface: PSurface, x_offset, y_offset: var float64) {.importc: "cairo_surface_get_device_offset".}
-proc setFallbackResolution*(surface: PSurface, x_pixels_per_inch, y_pixels_per_inch: float64) {.importc: "cairo_surface_set_fallback_resolution".}
+proc surfaceCreateSimilar*(other: ptr Surface, content: Content, width, height: int32): ptr Surface {.importc: "cairo_surface_create_similar".}
+proc reference*(surface: ptr Surface): ptr Surface {.importc: "cairo_surface_reference".}
+proc finish*(surface: ptr Surface) {.importc: "cairo_surface_finish".}
+proc destroy*(surface: ptr Surface) {.importc: "cairo_surface_destroy".}
+proc getReferenceCount*(surface: ptr Surface): int32 {.importc: "cairo_surface_get_reference_count".}
+proc status*(surface: ptr Surface): Status {.importc: "cairo_surface_status".}
+proc getType*(surface: ptr Surface): SurfaceType {.importc: "cairo_surface_get_type".}
+proc getContent*(surface: ptr Surface): Content {.importc: "cairo_surface_get_content".}
+proc writeToPng*(surface: ptr Surface, filename: cstring): Status{. cdecl, importc: "cairo_surface_write_to_png".}
+proc writeToPng*(surface: ptr Surface, write_func: WriteFunc, closure: pointer): Status {.importc: "cairo_surface_write_to_png_stream".}
+proc getUserData*(surface: ptr Surface, key: ptr UserDataKey): pointer{. cdecl, importc: "cairo_surface_get_user_data".}
+proc setUserData*(surface: ptr Surface, key: ptr UserDataKey, user_data: pointer, destroy: DestroyFunc): Status{. cdecl, importc: "cairo_surface_set_user_data".}
+proc getFontOptions*(surface: ptr Surface, options: ptr FontOptions) {.importc: "cairo_surface_get_font_options".}
+proc flush*(surface: ptr Surface) {.importc: "cairo_surface_flush".}
+proc markDirty*(surface: ptr Surface) {.importc: "cairo_surface_mark_dirty".}
+proc markDirtyRectangle*(surface: ptr Surface, x, y, width, height: int32){. cdecl, importc: "cairo_surface_mark_dirty_rectangle".}
+proc setDeviceOffset*(surface: ptr Surface, x_offset, y_offset: float64){. cdecl, importc: "cairo_surface_set_device_offset".}
+proc getDeviceOffset*(surface: ptr Surface, x_offset, y_offset: var float64) {.importc: "cairo_surface_get_device_offset".}
+proc setFallbackResolution*(surface: ptr Surface, x_pixels_per_inch, y_pixels_per_inch: float64) {.importc: "cairo_surface_set_fallback_resolution".}
 # Image-surface functions
-proc imageSurfaceCreate*(format: TFormat, width, height: int32): PSurface{. cdecl, importc: "cairo_image_surface_create".}
-proc imageSurfaceCreate*(data: Pbyte, format: TFormat, width, height, stride: int32): PSurface{. cdecl, importc: "cairo_image_surface_create_for_data".}
-proc getData*(surface: PSurface): cstring {.importc: "cairo_image_surface_get_data".}
-proc getFormat*(surface: PSurface): TFormat {.importc: "cairo_image_surface_get_format".}
-proc getWidth*(surface: PSurface): int32 {.importc: "cairo_image_surface_get_width".}
-proc getHeight*(surface: PSurface): int32 {.importc: "cairo_image_surface_get_height".}
-proc getStride*(surface: PSurface): int32 {.importc: "cairo_image_surface_get_stride".}
-proc imageSurfaceCreateFromPng*(filename: cstring): PSurface {.importc: "cairo_image_surface_create_from_png".}
-proc imageSurfaceCreateFromPng*(read_func: TReadFunc, closure: pointer): PSurface {.importc: "cairo_image_surface_create_from_png_stream".}
+proc imageSurfaceCreate*(format: Format, width, height: int32): ptr Surface{. cdecl, importc: "cairo_image_surface_create".}
+proc imageSurfaceCreate*(data: cstring, format: Format, width, height, stride: int32): ptr Surface{. cdecl, importc: "cairo_image_surface_create_for_data".}
+proc getData*(surface: ptr Surface): cstring {.importc: "cairo_image_surface_get_data".}
+proc getFormat*(surface: ptr Surface): Format {.importc: "cairo_image_surface_get_format".}
+proc getWidth*(surface: ptr Surface): int32 {.importc: "cairo_image_surface_get_width".}
+proc getHeight*(surface: ptr Surface): int32 {.importc: "cairo_image_surface_get_height".}
+proc getStride*(surface: ptr Surface): int32 {.importc: "cairo_image_surface_get_stride".}
+proc imageSurfaceCreateFromPng*(filename: cstring): ptr Surface {.importc: "cairo_image_surface_create_from_png".}
+proc imageSurfaceCreateFromPng*(read_func: ReadFunc, closure: pointer): ptr Surface {.importc: "cairo_image_surface_create_from_png_stream".}
 # Pattern creation functions
-proc patternCreateRgb*(red, green, blue: float64): PPattern {.importc: "cairo_pattern_create_rgb".}
-proc patternCreateRgba*(red, green, blue, alpha: float64): PPattern {.importc: "cairo_pattern_create_rgba".}
-proc patternCreateForSurface*(surface: PSurface): PPattern {.importc: "cairo_pattern_create_for_surface".}
-proc patternCreateLinear*(x0, y0, x1, y1: float64): PPattern {.importc: "cairo_pattern_create_linear".}
-proc patternCreateRadial*(cx0, cy0, radius0, cx1, cy1, radius1: float64): PPattern{. cdecl, importc: "cairo_pattern_create_radial".}
-proc reference*(pattern: PPattern): PPattern {.importc: "cairo_pattern_reference".}
-proc destroy*(pattern: PPattern) {.importc: "cairo_pattern_destroy".}
-proc getReferenceCount*(pattern: PPattern): int32 {.importc: "cairo_pattern_get_reference_count".}
-proc status*(pattern: PPattern): TStatus {.importc: "cairo_pattern_status".}
-proc getUserData*(pattern: PPattern, key: PUserDataKey): pointer{. cdecl, importc: "cairo_pattern_get_user_data".}
-proc setUserData*(pattern: PPattern, key: PUserDataKey, user_data: pointer, destroy: TDestroyFunc): TStatus{. cdecl, importc: "cairo_pattern_set_user_data".}
-proc getType*(pattern: PPattern): TPatternType {.importc: "cairo_pattern_get_type".}
-proc addColorStopRgb*(pattern: PPattern, offset, red, green, blue: float64) {.importc: "cairo_pattern_add_color_stop_rgb".}
-proc addColorStopRgba*(pattern: PPattern, offset, red, green, blue, alpha: float64){. cdecl, importc: "cairo_pattern_add_color_stop_rgba".}
-proc setMatrix*(pattern: PPattern, matrix: PMatrix) {.importc: "cairo_pattern_set_matrix".}
-proc getMatrix*(pattern: PPattern, matrix: PMatrix) {.importc: "cairo_pattern_get_matrix".}
-proc setExtend*(pattern: PPattern, extend: TExtend) {.importc: "cairo_pattern_set_extend".}
-proc getExtend*(pattern: PPattern): TExtend {.importc: "cairo_pattern_get_extend".}
-proc setFilter*(pattern: PPattern, filter: TFilter) {.importc: "cairo_pattern_set_filter".}
-proc getFilter*(pattern: PPattern): TFilter {.importc: "cairo_pattern_get_filter".}
-proc getRgba*(pattern: PPattern, red, green, blue, alpha: var float64): TStatus{. cdecl, importc: "cairo_pattern_get_rgba".}
-proc getSurface*(pattern: PPattern, surface: PPSurface): TStatus{. cdecl, importc: "cairo_pattern_get_surface".}
-proc getColorStopRgba*(pattern: PPattern, index: int32, offset, red, green, blue, alpha: var float64): TStatus{. cdecl, importc: "cairo_pattern_get_color_stop_rgba".}
-proc getColorStopCount*(pattern: PPattern, count: var int32): TStatus{. cdecl, importc: "cairo_pattern_get_color_stop_count".}
-proc getLinearPoints*(pattern: PPattern, x0, y0, x1, y1: var float64): TStatus{. cdecl, importc: "cairo_pattern_get_linear_points".}
-proc getRadialCircles*(pattern: PPattern, x0, y0, r0, x1, y1, r1: var float64): TStatus{. cdecl, importc: "cairo_pattern_get_radial_circles".}
+proc patternCreateRgb*(red, green, blue: float64): ptr Pattern {.importc: "cairo_pattern_create_rgb".}
+proc patternCreateRgba*(red, green, blue, alpha: float64): ptr Pattern {.importc: "cairo_pattern_create_rgba".}
+proc patternCreateForSurface*(surface: ptr Surface): ptr Pattern {.importc: "cairo_pattern_create_for_surface".}
+proc patternCreateLinear*(x0, y0, x1, y1: float64): ptr Pattern {.importc: "cairo_pattern_create_linear".}
+proc patternCreateRadial*(cx0, cy0, radius0, cx1, cy1, radius1: float64): ptr Pattern{. cdecl, importc: "cairo_pattern_create_radial".}
+proc reference*(pattern: ptr Pattern): ptr Pattern {.importc: "cairo_pattern_reference".}
+proc destroy*(pattern: ptr Pattern) {.importc: "cairo_pattern_destroy".}
+proc getReferenceCount*(pattern: ptr Pattern): int32 {.importc: "cairo_pattern_get_reference_count".}
+proc status*(pattern: ptr Pattern): Status {.importc: "cairo_pattern_status".}
+proc getUserData*(pattern: ptr Pattern, key: ptr UserDataKey): pointer{. cdecl, importc: "cairo_pattern_get_user_data".}
+proc setUserData*(pattern: ptr Pattern, key: ptr UserDataKey, user_data: pointer, destroy: DestroyFunc): Status{. cdecl, importc: "cairo_pattern_set_user_data".}
+proc getType*(pattern: ptr Pattern): PatternType {.importc: "cairo_pattern_get_type".}
+proc addColorStopRgb*(pattern: ptr Pattern, offset, red, green, blue: float64) {.importc: "cairo_pattern_add_color_stop_rgb".}
+proc addColorStopRgba*(pattern: ptr Pattern, offset, red, green, blue, alpha: float64){. cdecl, importc: "cairo_pattern_add_color_stop_rgba".}
+proc setMatrix*(pattern: ptr Pattern, matrix: ptr Matrix) {.importc: "cairo_pattern_set_matrix".}
+proc getMatrix*(pattern: ptr Pattern, matrix: ptr Matrix) {.importc: "cairo_pattern_get_matrix".}
+proc setExtend*(pattern: ptr Pattern, extend: Extend) {.importc: "cairo_pattern_set_extend".}
+proc getExtend*(pattern: ptr Pattern): Extend {.importc: "cairo_pattern_get_extend".}
+proc setFilter*(pattern: ptr Pattern, filter: Filter) {.importc: "cairo_pattern_set_filter".}
+proc getFilter*(pattern: ptr Pattern): Filter {.importc: "cairo_pattern_get_filter".}
+proc getRgba*(pattern: ptr Pattern, red, green, blue, alpha: var float64): Status{. cdecl, importc: "cairo_pattern_get_rgba".}
+proc getSurface*(pattern: ptr Pattern, surface: ptr ptr Surface): Status{. cdecl, importc: "cairo_pattern_get_surface".}
+proc getColorStopRgba*(pattern: ptr Pattern, index: int32, offset, red, green, blue, alpha: var float64): Status{. cdecl, importc: "cairo_pattern_get_color_stop_rgba".}
+proc getColorStopCount*(pattern: ptr Pattern, count: var int32): Status{. cdecl, importc: "cairo_pattern_get_color_stop_count".}
+proc getLinearPoints*(pattern: ptr Pattern, x0, y0, x1, y1: var float64): Status{. cdecl, importc: "cairo_pattern_get_linear_points".}
+proc getRadialCircles*(pattern: ptr Pattern, x0, y0, r0, x1, y1, r1: var float64): Status{. cdecl, importc: "cairo_pattern_get_radial_circles".}
 # Matrix functions
-proc init*(matrix: PMatrix, xx, yx, xy, yy, x0, y0: float64) {.importc: "cairo_matrix_init".}
-proc initIdentity*(matrix: PMatrix) {.importc: "cairo_matrix_init_identity".}
-proc initTranslate*(matrix: PMatrix, tx, ty: float64) {.importc: "cairo_matrix_init_translate".}
-proc initScale*(matrix: PMatrix, sx, sy: float64) {.importc: "cairo_matrix_init_scale".}
-proc initRotate*(matrix: PMatrix, radians: float64) {.importc: "cairo_matrix_init_rotate".}
-proc translate*(matrix: PMatrix, tx, ty: float64) {.importc: "cairo_matrix_translate".}
-proc scale*(matrix: PMatrix, sx, sy: float64) {.importc: "cairo_matrix_scale".}
-proc rotate*(matrix: PMatrix, radians: float64) {.importc: "cairo_matrix_rotate".}
-proc invert*(matrix: PMatrix): TStatus {.importc: "cairo_matrix_invert".}
-proc multiply*(result, a, b: PMatrix) {.importc: "cairo_matrix_multiply".}
-proc transformDistance*(matrix: PMatrix, dx, dy: var float64) {.importc: "cairo_matrix_transform_distance".}
-proc transformPoint*(matrix: PMatrix, x, y: var float64) {.importc: "cairo_matrix_transform_point".}
+proc init*(matrix: ptr Matrix, xx, yx, xy, yy, x0, y0: float64) {.importc: "cairo_matrix_init".}
+proc initIdentity*(matrix: ptr Matrix) {.importc: "cairo_matrix_init_identity".}
+proc initTranslate*(matrix: ptr Matrix, tx, ty: float64) {.importc: "cairo_matrix_init_translate".}
+proc initScale*(matrix: ptr Matrix, sx, sy: float64) {.importc: "cairo_matrix_init_scale".}
+proc initRotate*(matrix: ptr Matrix, radians: float64) {.importc: "cairo_matrix_init_rotate".}
+proc translate*(matrix: ptr Matrix, tx, ty: float64) {.importc: "cairo_matrix_translate".}
+proc scale*(matrix: ptr Matrix, sx, sy: float64) {.importc: "cairo_matrix_scale".}
+proc rotate*(matrix: ptr Matrix, radians: float64) {.importc: "cairo_matrix_rotate".}
+proc invert*(matrix: ptr Matrix): Status {.importc: "cairo_matrix_invert".}
+proc multiply*(result, a, b: ptr Matrix) {.importc: "cairo_matrix_multiply".}
+proc transformDistance*(matrix: ptr Matrix, dx, dy: var float64) {.importc: "cairo_matrix_transform_distance".}
+proc transformPoint*(matrix: ptr Matrix, x, y: var float64) {.importc: "cairo_matrix_transform_point".}
 # PDF functions
-proc pdfSurfaceCreate*(filename: cstring, width_in_points, height_in_points: float64): PSurface{. cdecl, importc: "cairo_pdf_surface_create".}
-proc pdfSurfaceCreateForStream*(write_func: TWriteFunc, closure: pointer, width_in_points, height_in_points: float64): PSurface{. cdecl, importc: "cairo_pdf_surface_create_for_stream".}
-proc pdfSurfaceSetSize*(surface: PSurface, width_in_points, height_in_points: float64) {.importc: "cairo_pdf_surface_set_size".}
+proc pdfSurfaceCreate*(filename: cstring, width_in_points, height_in_points: float64): ptr Surface{. cdecl, importc: "cairo_pdf_surface_create".}
+proc pdfSurfaceCreateForStream*(write_func: WriteFunc, closure: pointer, width_in_points, height_in_points: float64): ptr Surface{. cdecl, importc: "cairo_pdf_surface_create_for_stream".}
+proc pdfSurfaceSetSize*(surface: ptr Surface, width_in_points, height_in_points: float64) {.importc: "cairo_pdf_surface_set_size".}
 # PS functions
-proc psSurfaceCreate*(filename: cstring, width_in_points, height_in_points: float64): PSurface{. cdecl, importc: "cairo_ps_surface_create".}
-proc psSurfaceCreateForStream*(write_func: TWriteFunc, closure: pointer, width_in_points, height_in_points: float64): PSurface{. cdecl, importc: "cairo_ps_surface_create_for_stream".}
-proc psSurfaceSetSize*(surface: PSurface, width_in_points, height_in_points: float64) {.importc: "cairo_ps_surface_set_size".}
-proc psSurfaceDscComment*(surface: PSurface, comment: cstring) {.importc: "cairo_ps_surface_dsc_comment".}
-proc psSurfaceDscBeginSetup*(surface: PSurface) {.importc: "cairo_ps_surface_dsc_begin_setup".}
-proc psSurfaceDscBeginPageSetup*(surface: PSurface) {.importc: "cairo_ps_surface_dsc_begin_page_setup".}
+proc psSurfaceCreate*(filename: cstring, width_in_points, height_in_points: float64): ptr Surface{. cdecl, importc: "cairo_ps_surface_create".}
+proc psSurfaceCreateForStream*(write_func: WriteFunc, closure: pointer, width_in_points, height_in_points: float64): ptr Surface{. cdecl, importc: "cairo_ps_surface_create_for_stream".}
+proc psSurfaceSetSize*(surface: ptr Surface, width_in_points, height_in_points: float64) {.importc: "cairo_ps_surface_set_size".}
+proc psSurfaceDscComment*(surface: ptr Surface, comment: cstring) {.importc: "cairo_ps_surface_dsc_comment".}
+proc psSurfaceDscBeginSetup*(surface: ptr Surface) {.importc: "cairo_ps_surface_dsc_begin_setup".}
+proc psSurfaceDscBeginPageSetup*(surface: ptr Surface) {.importc: "cairo_ps_surface_dsc_begin_page_setup".}
 # SVG functions
-proc svgSurfaceCreate*(filename: cstring, width_in_points, height_in_points: float64): PSurface{. cdecl, importc: "cairo_svg_surface_create".}
-proc svgSurfaceCreateForStream*(write_func: TWriteFunc, closure: pointer, width_in_points, height_in_points: float64): PSurface{. cdecl, importc: "cairo_svg_surface_create_for_stream".}
-proc svgSurfaceRestrictToVersion*(surface: PSurface, version: TSvgVersion){. cdecl, importc: "cairo_svg_surface_restrict_to_version".}
+proc svgSurfaceCreate*(filename: cstring, width_in_points, height_in_points: float64): ptr Surface{. cdecl, importc: "cairo_svg_surface_create".}
+proc svgSurfaceCreateForStream*(write_func: WriteFunc, closure: pointer, width_in_points, height_in_points: float64): ptr Surface{. cdecl, importc: "cairo_svg_surface_create_for_stream".}
+proc svgSurfaceRestrictToVersion*(surface: ptr Surface, version: SvgVersion){. cdecl, importc: "cairo_svg_surface_restrict_to_version".}
   #todo: see how translate this
-  #procedure cairo_svg_get_versions(TCairoSvgVersion const **versions, # int *num_versions); proc svgVersionToString*(version: TSvgVersion): cstring {.importc: "cairo_svg_version_to_string".}
+  #procedure cairo_svg_get_versions(TCairoSvgVersion const **versions, # int *num_versions); proc svgVersionToString*(version: SvgVersion): cstring {.importc: "cairo_svg_version_to_string".}
 # Functions to be used while debugging (not intended for use in production code)
 proc debugResetStaticData*() {.importc: "cairo_debug_reset_static_data".}
 
 # new since 1.10
-proc surfaceCreateForRectangle*(target: PSurface, x,y,w,h: cdouble): PSurface  {.importc: "cairo_surface_create_for_rectangle".}
+proc surfaceCreateForRectangle*(target: ptr Surface, x,y,w,h: cdouble): ptr Surface  {.importc: "cairo_surface_create_for_rectangle".}
 
 {.pop.}
 
@@ -482,7 +461,7 @@ proc version*(major, minor, micro: var int32) =
   minor = (version mod (major * 10000'i32)) div 100'i32
   micro = (version mod ((major * 10000'i32) + (minor * 100'i32)))
 
-proc checkStatus*(s: cairo.TStatus) {.noinline.} =
+proc checkStatus*(s: Status) {.noinline.} =
   ## if ``s != StatusSuccess`` the error is turned into an appropirate Nimrod
   ## exception and raised.
   case s
@@ -495,3 +474,85 @@ proc checkStatus*(s: cairo.TStatus) {.noinline.} =
   else:
     raise newException(AssertionError, $statusToString(s))
 
+
+type
+  PPSurface*  {.deprecated: "ptr ptr Surface".} = ptr ptr Surface
+  PByte* {.deprecated: "use cstring".} = cstring
+  TStatus* {.deprecated: "use Status".} = Status
+  PStatus* {.deprecated: "use ptr Status".} = ptr Status
+  TOperator* {.deprecated: "use Operator".} = Operator
+  POperator* {.deprecated: "use ptr Operator".} = ptr Operator
+  TAntialias* {.deprecated: "use Antialias".} = Antialias
+  PAntialias* {.deprecated: "use ptr Antialias".} = ptr Antialias
+  TFillRule* {.deprecated: "use FillRule".} = FillRule
+  PFillRule* {.deprecated: "use ptr FillRule".} = ptr FillRule
+  TLineCap* {.deprecated: "use LineCap".} = LineCap
+  PLineCap* {.deprecated: "use ptr LineCap".} = ptr LineCap
+  TLineJoin* {.deprecated: "use LineJoin".} = LineJoin
+  PLineJoin* {.deprecated: "use ptr LineJoin".} = ptr LineJoin
+  TFontSlant* {.deprecated: "use FontSlant".} = FontSlant
+  PFontSlant* {.deprecated: "use ptr FontSlant".} = ptr FontSlant
+  TFontWeight* {.deprecated: "use FontWeight".} = FontWeight
+  PFontWeight* {.deprecated: "use ptr FontWeight".} = ptr FontWeight
+  TSubpixelOrder* {.deprecated: "use SubpixelOrder".} = SubpixelOrder
+  PSubpixelOrder* {.deprecated: "use ptr SubpixelOrder".} = ptr SubpixelOrder
+  THintStyle* {.deprecated: "use HintStyle".} = HintStyle
+  PHintStyle* {.deprecated: "use ptr HintStyle".} = ptr HintStyle
+  THintMetrics* {.deprecated: "use HintMetrics".} = HintMetrics
+  PHintMetrics* {.deprecated: "use ptr HintMetrics".} = ptr HintMetrics
+  TPathDataType* {.deprecated: "use PathDataType".} = PathDataType
+  PPathDataType* {.deprecated: "use ptr PathDataType".} = ptr PathDataType
+  TContent* {.deprecated: "use Content".} = Content
+  PContent* {.deprecated: "use ptr Content".} = ptr Content
+  TFormat* {.deprecated: "use Format".} = Format
+  PFormat* {.deprecated: "use ptr Format".} = ptr Format
+  TExtend* {.deprecated: "use Extend".} = Extend
+  PExtend* {.deprecated: "use ptr Extend".} = ptr Extend
+  TFilter* {.deprecated: "use Filter".} = Filter
+  PFilter* {.deprecated: "use ptr Filter".} = ptr Filter
+  TFontType* {.deprecated: "use FontType".} = FontType
+  PFontType* {.deprecated: "use ptr FontType".} = ptr FontType
+  TPatternType* {.deprecated: "use PatternType".} = PatternType
+  PPatternType* {.deprecated: "use ptr PatternType".} = ptr PatternType
+  TSurfaceType* {.deprecated: "use SurfaceType".} = SurfaceType
+  PSurfaceType* {.deprecated: "use ptr SurfaceType".} = ptr SurfaceType
+  TSvgVersion* {.deprecated: "use SvgVersion".} = SvgVersion
+  PSvgVersion* {.deprecated: "use ptr SvgVersion".} = ptr SvgVersion
+  TBool* {.deprecated: "use Bool".} = Bool
+  PBool* {.deprecated: "use ptr Bool".} = ptr Bool
+  TDestroyFunc* {.deprecated: "use DestroyFunc".} = DestroyFunc
+  PDestroyFunc* {.deprecated: "use ptr DestroyFunc".} = ptr DestroyFunc
+  TWriteFunc* {.deprecated: "use WriteFunc".} = WriteFunc
+  PWriteFunc* {.deprecated: "use ptr WriteFunc".} = ptr WriteFunc
+  TReadFunc* {.deprecated: "use ReadFunc".} = ReadFunc
+  PReadFunc* {.deprecated: "use ptr ReadFunc".} = ptr ReadFunc
+  TContext* {.deprecated: "use Context".} = Context
+  PContext* {.deprecated: "use ptr Context".} = ptr Context
+  TSurface* {.deprecated: "use Surface".} = Surface
+  PSurface* {.deprecated: "use ptr Surface".} = ptr Surface
+  TPattern* {.deprecated: "use Pattern".} = Pattern
+  PPattern* {.deprecated: "use ptr Pattern".} = ptr Pattern
+  TScaledFont* {.deprecated: "use ScaledFont".} = ScaledFont
+  PScaledFont* {.deprecated: "use ptr ScaledFont".} = ptr ScaledFont
+  TFontFace* {.deprecated: "use FontFace".} = FontFace
+  PFontFace* {.deprecated: "use ptr FontFace".} = ptr FontFace
+  TFontOptions* {.deprecated: "use FontOptions".} = FontOptions
+  PFontOptions* {.deprecated: "use ptr FontOptions".} = ptr FontOptions
+  TMatrix* {.deprecated: "use Matrix".} = Matrix
+  PMatrix* {.deprecated: "use ptr Matrix".} = ptr Matrix
+  TUserDataKey* {.deprecated: "use UserDataKey".} = UserDataKey
+  PUserDataKey* {.deprecated: "use ptr UserDataKey".} = ptr UserDataKey
+  TGlyph* {.deprecated: "use Glyph".} = Glyph
+  PGlyph* {.deprecated: "use ptr Glyph".} = ptr Glyph
+  TTextExtents* {.deprecated: "use TextExtents".} = TextExtents
+  PTextExtents* {.deprecated: "use ptr TextExtents".} = ptr TextExtents
+  TFontExtents* {.deprecated: "use FontExtents".} = FontExtents
+  PFontExtents* {.deprecated: "use ptr FontExtents".} = ptr FontExtents
+  TPathData* {.deprecated: "use PathData".} = PathData
+  PPathData* {.deprecated: "use ptr PathData".} = ptr PathData
+  TPath* {.deprecated: "use Path".} = Path
+  PPath* {.deprecated: "use ptr Path".} = ptr Path
+  TRectangle* {.deprecated: "use Rectangle".} = Rectangle
+  PRectangle* {.deprecated: "use ptr Rectangle".} = ptr Rectangle
+  TRectangleList* {.deprecated: "use RectangleList".} = RectangleList
+  PRectangleList* {.deprecated: "use ptr RectangleList".} = ptr RectangleList

--- a/src/cairo.nim
+++ b/src/cairo.nim
@@ -50,9 +50,9 @@
 
 include "cairo_pragma.nim"
 
-type 
+type
   PByte = cstring
-  TStatus* = enum 
+  TStatus* = enum
     STATUS_SUCCESS = 0,
     STATUS_NO_MEMORY,
     STATUS_INVALID_RESTORE,
@@ -86,8 +86,8 @@ type
     STATUS_INVALID_SLANT,
     STATUS_INVALID_WEIGHT
 
-    
-  TOperator* = enum 
+
+  TOperator* = enum
     OPERATOR_CLEAR, OPERATOR_SOURCE, OPERATOR_OVER, OPERATOR_IN, OPERATOR_OUT,
     OPERATOR_ATOP, OPERATOR_DEST, OPERATOR_DEST_OVER, OPERATOR_DEST_IN,
     OPERATOR_DEST_OUT, OPERATOR_DEST_ATOP, OPERATOR_XOR, OPERATOR_ADD,
@@ -96,50 +96,50 @@ type
     OPERATOR_COLOR_BURN, OPERATOR_HARD_LIGHT, OPERATOR_SOFT_LIGHT,
     OPERATOR_DIFFERENCE, OPERATOR_EXCLUSION, OPERATOR_HSL_HUE,
     OPERATOR_HSL_SATURATION, OPERATOR_HSL_COLOR, OPERATOR_HSL_LUMINOSITY
-    
-  TAntialias* = enum 
+
+  TAntialias* = enum
     ANTIALIAS_DEFAULT, ANTIALIAS_NONE, ANTIALIAS_GRAY, ANTIALIAS_SUBPIXEL
-  TFillRule* = enum 
+  TFillRule* = enum
     FILL_RULE_WINDING, FILL_RULE_EVEN_ODD
-  TLineCap* = enum 
+  TLineCap* = enum
     LINE_CAP_BUTT, LINE_CAP_ROUND, LINE_CAP_SQUARE
-  TLineJoin* = enum 
+  TLineJoin* = enum
     LINE_JOIN_MITER, LINE_JOIN_ROUND, LINE_JOIN_BEVEL
-  TFontSlant* = enum 
+  TFontSlant* = enum
     FONT_SLANT_NORMAL, FONT_SLANT_ITALIC, FONT_SLANT_OBLIQUE
-  TFontWeight* = enum 
+  TFontWeight* = enum
     FONT_WEIGHT_NORMAL, FONT_WEIGHT_BOLD
-  TSubpixelOrder* = enum 
-    SUBPIXEL_ORDER_DEFAULT, SUBPIXEL_ORDER_RGB, SUBPIXEL_ORDER_BGR, 
+  TSubpixelOrder* = enum
+    SUBPIXEL_ORDER_DEFAULT, SUBPIXEL_ORDER_RGB, SUBPIXEL_ORDER_BGR,
     SUBPIXEL_ORDER_VRGB, SUBPIXEL_ORDER_VBGR
-  THintStyle* = enum 
-    HINT_STYLE_DEFAULT, HINT_STYLE_NONE, HINT_STYLE_SLIGHT, HINT_STYLE_MEDIUM, 
+  THintStyle* = enum
+    HINT_STYLE_DEFAULT, HINT_STYLE_NONE, HINT_STYLE_SLIGHT, HINT_STYLE_MEDIUM,
     HINT_STYLE_FULL
-  THintMetrics* = enum 
+  THintMetrics* = enum
     HINT_METRICS_DEFAULT, HINT_METRICS_OFF, HINT_METRICS_ON
-  TPathDataType* = enum 
+  TPathDataType* = enum
     PATH_MOVE_TO, PATH_LINE_TO, PATH_CURVE_TO, PATH_CLOSE_PATH
-  TContent* = enum 
-    CONTENT_COLOR = 0x00001000, CONTENT_ALPHA = 0x00002000, 
+  TContent* = enum
+    CONTENT_COLOR = 0x00001000, CONTENT_ALPHA = 0x00002000,
     CONTENT_COLOR_ALPHA = 0x00003000
-  TFormat* = enum 
+  TFormat* = enum
     FORMAT_ARGB32, FORMAT_RGB24, FORMAT_A8, FORMAT_A1
-  TExtend* = enum 
+  TExtend* = enum
     EXTEND_NONE, EXTEND_REPEAT, EXTEND_REFLECT, EXTEND_PAD
-  TFilter* = enum 
-    FILTER_FAST, FILTER_GOOD, FILTER_BEST, FILTER_NEAREST, FILTER_BILINEAR, 
+  TFilter* = enum
+    FILTER_FAST, FILTER_GOOD, FILTER_BEST, FILTER_NEAREST, FILTER_BILINEAR,
     FILTER_GAUSSIAN
-  TFontType* = enum 
+  TFontType* = enum
     FONT_TYPE_TOY, FONT_TYPE_FT, FONT_TYPE_WIN32, FONT_TYPE_ATSUI
-  TPatternType* = enum 
-    PATTERN_TYPE_SOLID, PATTERN_TYPE_SURFACE, PATTERN_TYPE_LINEAR, 
+  TPatternType* = enum
+    PATTERN_TYPE_SOLID, PATTERN_TYPE_SURFACE, PATTERN_TYPE_LINEAR,
     PATTERN_TYPE_RADIAL
-  TSurfaceType* = enum 
-    SURFACE_TYPE_IMAGE, SURFACE_TYPE_PDF, SURFACE_TYPE_PS, SURFACE_TYPE_XLIB, 
-    SURFACE_TYPE_XCB, SURFACE_TYPE_GLITZ, SURFACE_TYPE_QUARTZ, 
-    SURFACE_TYPE_WIN32, SURFACE_TYPE_BEOS, SURFACE_TYPE_DIRECTFB, 
+  TSurfaceType* = enum
+    SURFACE_TYPE_IMAGE, SURFACE_TYPE_PDF, SURFACE_TYPE_PS, SURFACE_TYPE_XLIB,
+    SURFACE_TYPE_XCB, SURFACE_TYPE_GLITZ, SURFACE_TYPE_QUARTZ,
+    SURFACE_TYPE_WIN32, SURFACE_TYPE_BEOS, SURFACE_TYPE_DIRECTFB,
     SURFACE_TYPE_SVG, SURFACE_TYPE_OS2
-  TSvgVersion* = enum 
+  TSvgVersion* = enum
     SVG_VERSION_1_1, SVG_VERSION_1_2
   PSurface* = ptr TSurface
   PPSurface* = ptr PSurface
@@ -169,7 +169,7 @@ type
   TScaledFont*{.final.} = object  #OPAQUE
   TFontFace*{.final.} = object  #OPAQUE
   TFontOptions*{.final.} = object  #OPAQUE
-  TMatrix*{.final.} = object 
+  TMatrix*{.final.} = object
     xx*: float64
     yx*: float64
     xy*: float64
@@ -177,15 +177,15 @@ type
     x0*: float64
     y0*: float64
 
-  TUserDataKey*{.final.} = object 
+  TUserDataKey*{.final.} = object
     unused*: int32
 
-  TGlyph*{.final.} = object 
+  TGlyph*{.final.} = object
     index*: int32
     x*: float64
     y*: float64
 
-  TTextExtents*{.final.} = object 
+  TTextExtents*{.final.} = object
     x_bearing*: float64
     y_bearing*: float64
     width*: float64
@@ -193,7 +193,7 @@ type
     x_advance*: float64
     y_advance*: float64
 
-  TFontExtents*{.final.} = object 
+  TFontExtents*{.final.} = object
     ascent*: float64
     descent*: float64
     height*: float64
@@ -206,537 +206,292 @@ type
     x*: float64
     y*: float64
 
-  TPath*{.final.} = object 
+  TPath*{.final.} = object
     status*: TStatus
     data*: PPathData
     num_data*: int32
 
-  TRectangle*{.final.} = object 
+  TRectangle*{.final.} = object
     x*, y*, width*, height*: float64
 
-  TRectangleList*{.final.} = object 
+  TRectangleList*{.final.} = object
     status*: TStatus
     rectangles*: PRectangle
     num_rectangles*: int32
 
+{.push dynlib: LIB_CAIRO, cdecl.}
 
-proc version*(): int32{.cdecl, importc: "cairo_version", libcairo.}
-proc versionString*(): cstring{.cdecl, importc: "cairo_version_string", 
-                                 libcairo.}
-  #Helper function to retrieve decoded version
-proc version*(major, minor, micro: var int32)
-  #* Functions for manipulating state objects
-proc create*(target: PSurface): PContext{.cdecl, importc: "cairo_create", 
-                                   libcairo.}
-proc reference*(cr: PContext): PContext{.cdecl, importc: "cairo_reference", libcairo.}
-proc destroy*(cr: PContext){.cdecl, importc: "cairo_destroy", libcairo.}
-proc getReferenceCount*(cr: PContext): int32{.cdecl, 
-    importc: "cairo_get_reference_count", libcairo.}
-proc getUserData*(cr: PContext, key: PUserDataKey): pointer{.cdecl, 
-    importc: "cairo_get_user_data", libcairo.}
-proc setUserData*(cr: PContext, key: PUserDataKey, user_data: pointer, 
-                    destroy: TDestroyFunc): TStatus{.cdecl, 
-    importc: "cairo_set_user_data", libcairo.}
-proc save*(cr: PContext){.cdecl, importc: "cairo_save", libcairo.}
-proc restore*(cr: PContext){.cdecl, importc: "cairo_restore", libcairo.}
-proc pushGroup*(cr: PContext){.cdecl, importc: "cairo_push_group", libcairo.}
-proc pushGroupWithContent*(cr: PContext, content: TContent){.cdecl, 
-    importc: "cairo_push_group_with_content", libcairo.}
-proc popGroup*(cr: PContext): PPattern{.cdecl, importc: "cairo_pop_group", 
-                                  libcairo.}
-proc popGroupToSource*(cr: PContext){.cdecl, importc: "cairo_pop_group_to_source", 
-                                  libcairo.}
-  #* Modify state
-proc setOperator*(cr: PContext, op: TOperator){.cdecl, importc: "cairo_set_operator", 
-    libcairo.}
-proc setSource*(cr: PContext, source: PPattern){.cdecl, importc: "cairo_set_source", 
-    libcairo.}
-proc setSourceRgb*(cr: PContext, red, green, blue: float64){.cdecl, 
-    importc: "cairo_set_source_rgb", libcairo.}
-proc setSourceRgba*(cr: PContext, red, green, blue, alpha: float64){.cdecl, 
-    importc: "cairo_set_source_rgba", libcairo.}
-proc setSource*(cr: PContext, surface: PSurface, x, y: float64){.cdecl, 
-    importc: "cairo_set_source_surface", libcairo.}
-proc setTolerance*(cr: PContext, tolerance: float64){.cdecl, 
-    importc: "cairo_set_tolerance", libcairo.}
-proc setAntialias*(cr: PContext, antialias: TAntialias){.cdecl, 
-    importc: "cairo_set_antialias", libcairo.}
-proc setFillRule*(cr: PContext, fill_rule: TFillRule){.cdecl, 
-    importc: "cairo_set_fill_rule", libcairo.}
-proc setLineWidth*(cr: PContext, width: float64){.cdecl, 
-    importc: "cairo_set_line_width", libcairo.}
-proc setLineCap*(cr: PContext, line_cap: TLineCap){.cdecl, 
-    importc: "cairo_set_line_cap", libcairo.}
-proc setLineJoin*(cr: PContext, line_join: TLineJoin){.cdecl, 
-    importc: "cairo_set_line_join", libcairo.}
-proc setDash*(cr: PContext, dashes: openarray[float64], offset: float64){.cdecl, 
-    importc: "cairo_set_dash", libcairo.}
-proc setMiterLimit*(cr: PContext, limit: float64){.cdecl, 
-    importc: "cairo_set_miter_limit", libcairo.}
-proc translate*(cr: PContext, tx, ty: float64){.cdecl, importc: "cairo_translate", 
-    libcairo.}
-proc scale*(cr: PContext, sx, sy: float64){.cdecl, importc: "cairo_scale", 
-                                     libcairo.}
-proc rotate*(cr: PContext, angle: float64){.cdecl, importc: "cairo_rotate", 
-                                     libcairo.}
-proc transform*(cr: PContext, matrix: PMatrix){.cdecl, importc: "cairo_transform", 
-    libcairo.}
-proc setMatrix*(cr: PContext, matrix: PMatrix){.cdecl, importc: "cairo_set_matrix", 
-    libcairo.}
-proc identityMatrix*(cr: PContext){.cdecl, importc: "cairo_identity_matrix", 
-                              libcairo.}
-proc userToDevice*(cr: PContext, x, y: var float64){.cdecl, 
-    importc: "cairo_user_to_device", libcairo.}
-proc userToDeviceDistance*(cr: PContext, dx, dy: var float64){.cdecl, 
-    importc: "cairo_user_to_device_distance", libcairo.}
-proc deviceToUser*(cr: PContext, x, y: var float64){.cdecl, 
-    importc: "cairo_device_to_user", libcairo.}
-proc deviceToUserDistance*(cr: PContext, dx, dy: var float64){.cdecl, 
-    importc: "cairo_device_to_user_distance", libcairo.}
-  #* Path creation functions
-proc newPath*(cr: PContext){.cdecl, importc: "cairo_new_path", libcairo.}
-proc moveTo*(cr: PContext, x, y: float64){.cdecl, importc: "cairo_move_to", 
-                                     libcairo.}
-proc newSubPath*(cr: PContext){.cdecl, importc: "cairo_new_sub_path", 
-                           libcairo.}
-proc lineTo*(cr: PContext, x, y: float64){.cdecl, importc: "cairo_line_to", 
-                                     libcairo.}
-proc curveTo*(cr: PContext, x1, y1, x2, y2, x3, y3: float64){.cdecl, 
-    importc: "cairo_curve_to", libcairo.}
-proc arc*(cr: PContext, xc, yc, radius, angle1, angle2: float64){.cdecl, 
-    importc: "cairo_arc", libcairo.}
-proc arcNegative*(cr: PContext, xc, yc, radius, angle1, angle2: float64){.cdecl, 
-    importc: "cairo_arc_negative", libcairo.}
-proc relMoveTo*(cr: PContext, dx, dy: float64){.cdecl, importc: "cairo_rel_move_to", 
-    libcairo.}
-proc relLineTo*(cr: PContext, dx, dy: float64){.cdecl, importc: "cairo_rel_line_to", 
-    libcairo.}
-proc relCurveTo*(cr: PContext, dx1, dy1, dx2, dy2, dx3, dy3: float64){.cdecl, 
-    importc: "cairo_rel_curve_to", libcairo.}
-proc rectangle*(cr: PContext, x, y, width, height: float64){.cdecl, 
-    importc: "cairo_rectangle", libcairo.}
-proc closePath*(cr: PContext){.cdecl, importc: "cairo_close_path", libcairo.}
-  #* Painting functions
-proc paint*(cr: PContext){.cdecl, importc: "cairo_paint", libcairo.}
-proc paintWithAlpha*(cr: PContext, alpha: float64){.cdecl, 
-    importc: "cairo_paint_with_alpha", libcairo.}
-proc mask*(cr: PContext, pattern: PPattern){.cdecl, importc: "cairo_mask", 
-                                      libcairo.}
-proc mask*(cr: PContext, surface: PSurface, surface_x, surface_y: float64){.
-    cdecl, importc: "cairo_mask_surface", libcairo.}
-proc stroke*(cr: PContext){.cdecl, importc: "cairo_stroke", libcairo.}
-proc strokePreserve*(cr: PContext){.cdecl, importc: "cairo_stroke_preserve", 
-                              libcairo.}
-proc fill*(cr: PContext){.cdecl, importc: "cairo_fill", libcairo.}
-proc fillPreserve*(cr: PContext){.cdecl, importc: "cairo_fill_preserve", 
-                            libcairo.}
-proc copyPage*(cr: PContext){.cdecl, importc: "cairo_copy_page", libcairo.}
-proc showPage*(cr: PContext){.cdecl, importc: "cairo_show_page", libcairo.}
-  #* Insideness testing
-proc inStroke*(cr: PContext, x, y: float64): TBool{.cdecl, importc: "cairo_in_stroke", 
-    libcairo.}
-proc inFill*(cr: PContext, x, y: float64): TBool{.cdecl, importc: "cairo_in_fill", 
-    libcairo.}
-  #* Rectangular extents
-proc strokeExtents*(cr: PContext, x1, y1, x2, y2: var float64){.cdecl, 
-    importc: "cairo_stroke_extents", libcairo.}
-proc fillExtents*(cr: PContext, x1, y1, x2, y2: var float64){.cdecl, 
-    importc: "cairo_fill_extents", libcairo.}
-  #* Clipping
-proc resetClip*(cr: PContext){.cdecl, importc: "cairo_reset_clip", libcairo.}
-proc clip*(cr: PContext){.cdecl, importc: "cairo_clip", libcairo.}
-proc clipPreserve*(cr: PContext){.cdecl, importc: "cairo_clip_preserve", 
-                            libcairo.}
-proc clipExtents*(cr: PContext, x1, y1, x2, y2: var float64){.cdecl, 
-    importc: "cairo_clip_extents", libcairo.}
-proc copyClipRectangleList*(cr: PContext): PRectangleList{.cdecl, 
-    importc: "cairo_copy_clip_rectangle_list", libcairo.}
-proc rectangleListDestroy*(rectangle_list: PRectangleList){.cdecl, 
-    importc: "cairo_rectangle_list_destroy", libcairo.}
-  #* Font/Text functions
-proc fontOptionsCreate*(): PFontOptions{.cdecl, 
-    importc: "cairo_font_options_create", libcairo.}
-proc copy*(original: PFontOptions): PFontOptions{.cdecl, 
-    importc: "cairo_font_options_copy", libcairo.}
-proc destroy*(options: PFontOptions){.cdecl, 
-    importc: "cairo_font_options_destroy", libcairo.}
-proc status*(options: PFontOptions): TStatus{.cdecl, 
-    importc: "cairo_font_options_status", libcairo.}
-proc merge*(options, other: PFontOptions){.cdecl, 
-    importc: "cairo_font_options_merge", libcairo.}
-proc equal*(options, other: PFontOptions): TBool{.cdecl, 
-    importc: "cairo_font_options_equal", libcairo.}
-proc hash*(options: PFontOptions): int32{.cdecl, 
-    importc: "cairo_font_options_hash", libcairo.}
-proc setAntialias*(options: PFontOptions, antialias: TAntialias){.
-    cdecl, importc: "cairo_font_options_set_antialias", libcairo.}
-proc getAntialias*(options: PFontOptions): TAntialias{.cdecl, 
-    importc: "cairo_font_options_get_antialias", libcairo.}
-proc setSubpixelOrder*(options: PFontOptions, 
-                                      subpixel_order: TSubpixelOrder){.cdecl, 
-    importc: "cairo_font_options_set_subpixel_order", libcairo.}
-proc getSubpixelOrder*(options: PFontOptions): TSubpixelOrder{.
-    cdecl, importc: "cairo_font_options_get_subpixel_order", libcairo.}
-proc setHintStyle*(options: PFontOptions, hint_style: THintStyle){.
-    cdecl, importc: "cairo_font_options_set_hint_style", libcairo.}
-proc getHintStyle*(options: PFontOptions): THintStyle{.cdecl, 
-    importc: "cairo_font_options_get_hint_style", libcairo.}
-proc setHintMetrics*(options: PFontOptions, 
-                                    hint_metrics: THintMetrics){.cdecl, 
-    importc: "cairo_font_options_set_hint_metrics", libcairo.}
-proc getHintMetrics*(options: PFontOptions): THintMetrics{.cdecl, 
-    importc: "cairo_font_options_get_hint_metrics", libcairo.}
-  #* This interface is for dealing with text as text, not caring about the
+proc version*(): int32 {.importc: "cairo_version".}
+proc versionString*(): cstring {.importc: "cairo_version_string".}
+proc create*(target: PSurface): PContext {.importc: "cairo_create".}
+proc reference*(cr: PContext): PContext {.importc: "cairo_reference".}
+proc destroy*(cr: PContext) {.importc: "cairo_destroy".}
+proc getReferenceCount*(cr: PContext): int32 {.importc: "cairo_get_reference_count".}
+proc getUserData*(cr: PContext, key: PUserDataKey): pointer {.importc: "cairo_get_user_data".}
+proc setUserData*(cr: PContext, key: PUserDataKey, user_data: pointer, destroy: TDestroyFunc): TStatus {.importc: "cairo_set_user_data".}
+proc save*(cr: PContext) {.importc: "cairo_save".}
+proc restore*(cr: PContext) {.importc: "cairo_restore".}
+proc pushGroup*(cr: PContext) {.importc: "cairo_push_group".}
+proc pushGroupWithContent*(cr: PContext, content: TContent) {.importc: "cairo_push_group_with_content".}
+proc popGroup*(cr: PContext): PPattern {.importc: "cairo_pop_group".}
+proc popGroupToSource*(cr: PContext) {.importc: "cairo_pop_group_to_source".}
+# Modify state
+proc setOperator*(cr: PContext, op: TOperator) {.importc: "cairo_set_operator".}
+proc setSource*(cr: PContext, source: PPattern) {.importc: "cairo_set_source".}
+proc setSourceRgb*(cr: PContext, red, green, blue: float64) {.importc: "cairo_set_source_rgb".}
+proc setSourceRgba*(cr: PContext, red, green, blue, alpha: float64) {.importc: "cairo_set_source_rgba".}
+proc setSource*(cr: PContext, surface: PSurface, x, y: float64) {.importc: "cairo_set_source_surface".}
+proc setTolerance*(cr: PContext, tolerance: float64) {.importc: "cairo_set_tolerance".}
+proc setAntialias*(cr: PContext, antialias: TAntialias) {.importc: "cairo_set_antialias".}
+proc setFillRule*(cr: PContext, fill_rule: TFillRule) {.importc: "cairo_set_fill_rule".}
+proc setLineWidth*(cr: PContext, width: float64) {.importc: "cairo_set_line_width".}
+proc setLineCap*(cr: PContext, line_cap: TLineCap) {.importc: "cairo_set_line_cap".}
+proc setLineJoin*(cr: PContext, line_join: TLineJoin) {.importc: "cairo_set_line_join".}
+proc setDash*(cr: PContext, dashes: openarray[float64], offset: float64) {.importc: "cairo_set_dash".}
+proc setMiterLimit*(cr: PContext, limit: float64) {.importc: "cairo_set_miter_limit".}
+proc translate*(cr: PContext, tx, ty: float64) {.importc: "cairo_translate".}
+proc scale*(cr: PContext, sx, sy: float64) {.importc: "cairo_scale".}
+proc rotate*(cr: PContext, angle: float64) {.importc: "cairo_rotate".}
+proc transform*(cr: PContext, matrix: PMatrix) {.importc: "cairo_transform".}
+proc setMatrix*(cr: PContext, matrix: PMatrix) {.importc: "cairo_set_matrix".}
+proc identityMatrix*(cr: PContext) {.importc: "cairo_identity_matrix".}
+proc userToDevice*(cr: PContext, x, y: var float64) {.importc: "cairo_user_to_device".}
+proc userToDeviceDistance*(cr: PContext, dx, dy: var float64) {.importc: "cairo_user_to_device_distance".}
+proc deviceToUser*(cr: PContext, x, y: var float64) {.importc: "cairo_device_to_user".}
+proc deviceToUserDistance*(cr: PContext, dx, dy: var float64) {.importc: "cairo_device_to_user_distance".}
+# Path creation functions
+proc newPath*(cr: PContext) {.importc: "cairo_new_path".}
+proc moveTo*(cr: PContext, x, y: float64) {.importc: "cairo_move_to".}
+proc newSubPath*(cr: PContext) {.importc: "cairo_new_sub_path".}
+proc lineTo*(cr: PContext, x, y: float64) {.importc: "cairo_line_to".}
+proc curveTo*(cr: PContext, x1, y1, x2, y2, x3, y3: float64) {.importc: "cairo_curve_to".}
+proc arc*(cr: PContext, xc, yc, radius, angle1, angle2: float64) {.importc: "cairo_arc".}
+proc arcNegative*(cr: PContext, xc, yc, radius, angle1, angle2: float64) {.importc: "cairo_arc_negative".}
+proc relMoveTo*(cr: PContext, dx, dy: float64) {.importc: "cairo_rel_move_to".}
+proc relLineTo*(cr: PContext, dx, dy: float64) {.importc: "cairo_rel_line_to".}
+proc relCurveTo*(cr: PContext, dx1, dy1, dx2, dy2, dx3, dy3: float64) {.importc: "cairo_rel_curve_to".}
+proc rectangle*(cr: PContext, x, y, width, height: float64) {.importc: "cairo_rectangle".}
+proc closePath*(cr: PContext) {.importc: "cairo_close_path".}
+# Painting functions
+proc paint*(cr: PContext) {.importc: "cairo_paint".}
+proc paintWithAlpha*(cr: PContext, alpha: float64) {.importc: "cairo_paint_with_alpha".}
+proc mask*(cr: PContext, pattern: PPattern) {.importc: "cairo_mask".}
+proc mask*(cr: PContext, surface: PSurface, surface_x, surface_y: float64){. cdecl, importc: "cairo_mask_surface".}
+proc stroke*(cr: PContext) {.importc: "cairo_stroke".}
+proc strokePreserve*(cr: PContext) {.importc: "cairo_stroke_preserve".}
+proc fill*(cr: PContext) {.importc: "cairo_fill".}
+proc fillPreserve*(cr: PContext) {.importc: "cairo_fill_preserve".}
+proc copyPage*(cr: PContext) {.importc: "cairo_copy_page".}
+proc showPage*(cr: PContext) {.importc: "cairo_show_page".}
+# Insideness testing
+proc inStroke*(cr: PContext, x, y: float64): TBool {.importc: "cairo_in_stroke".}
+proc inFill*(cr: PContext, x, y: float64): TBool {.importc: "cairo_in_fill".}
+# Rectangular extents
+proc strokeExtents*(cr: PContext, x1, y1, x2, y2: var float64) {.importc: "cairo_stroke_extents".}
+proc fillExtents*(cr: PContext, x1, y1, x2, y2: var float64) {.importc: "cairo_fill_extents".}
+# Clipping
+proc resetClip*(cr: PContext) {.importc: "cairo_reset_clip".}
+proc clip*(cr: PContext) {.importc: "cairo_clip".}
+proc clipPreserve*(cr: PContext) {.importc: "cairo_clip_preserve".}
+proc clipExtents*(cr: PContext, x1, y1, x2, y2: var float64) {.importc: "cairo_clip_extents".}
+proc copyClipRectangleList*(cr: PContext): PRectangleList {.importc: "cairo_copy_clip_rectangle_list".}
+proc rectangleListDestroy*(rectangle_list: PRectangleList) {.importc: "cairo_rectangle_list_destroy".}
+# Font/Text functions
+proc fontOptionsCreate*(): PFontOptions {.importc: "cairo_font_options_create".}
+proc copy*(original: PFontOptions): PFontOptions {.importc: "cairo_font_options_copy".}
+proc destroy*(options: PFontOptions) {.importc: "cairo_font_options_destroy".}
+proc status*(options: PFontOptions): TStatus {.importc: "cairo_font_options_status".}
+proc merge*(options, other: PFontOptions) {.importc: "cairo_font_options_merge".}
+proc equal*(options, other: PFontOptions): TBool {.importc: "cairo_font_options_equal".}
+proc hash*(options: PFontOptions): int32 {.importc: "cairo_font_options_hash".}
+proc setAntialias*(options: PFontOptions, antialias: TAntialias){. cdecl, importc: "cairo_font_options_set_antialias".}
+proc getAntialias*(options: PFontOptions): TAntialias {.importc: "cairo_font_options_get_antialias".}
+proc setSubpixelOrder*(options: PFontOptions, subpixel_order: TSubpixelOrder) {.importc: "cairo_font_options_set_subpixel_order".}
+proc getSubpixelOrder*(options: PFontOptions): TSubpixelOrder{. cdecl, importc: "cairo_font_options_get_subpixel_order".}
+proc setHintStyle*(options: PFontOptions, hint_style: THintStyle){. cdecl, importc: "cairo_font_options_set_hint_style".}
+proc getHintStyle*(options: PFontOptions): THintStyle {.importc: "cairo_font_options_get_hint_style".}
+proc setHintMetrics*(options: PFontOptions, hint_metrics: THintMetrics) {.importc: "cairo_font_options_set_hint_metrics".}
+proc getHintMetrics*(options: PFontOptions): THintMetrics {.importc: "cairo_font_options_get_hint_metrics".}
+# This interface is for dealing with text as text, not caring about the
   #   font object inside the the TCairo.
-proc selectFontFace*(cr: PContext, family: cstring, slant: TFontSlant, 
-                       weight: TFontWeight){.cdecl, 
-    importc: "cairo_select_font_face", libcairo.}
-proc setFontSize*(cr: PContext, size: float64){.cdecl, 
-    importc: "cairo_set_font_size", libcairo.}
-proc setFontMatrix*(cr: PContext, matrix: PMatrix){.cdecl, 
-    importc: "cairo_set_font_matrix", libcairo.}
-proc getFontMatrix*(cr: PContext, matrix: PMatrix){.cdecl, 
-    importc: "cairo_get_font_matrix", libcairo.}
-proc setFontOptions*(cr: PContext, options: PFontOptions){.cdecl, 
-    importc: "cairo_set_font_options", libcairo.}
-proc getFontOptions*(cr: PContext, options: PFontOptions){.cdecl, 
-    importc: "cairo_get_font_options", libcairo.}
-proc setFontFace*(cr: PContext, font_face: PFontFace){.cdecl, 
-    importc: "cairo_set_font_face", libcairo.}
-proc getFontFace*(cr: PContext): PFontFace{.cdecl, importc: "cairo_get_font_face", 
-                                       libcairo.}
-proc setScaledFont*(cr: PContext, scaled_font: PScaledFont){.cdecl, 
-    importc: "cairo_set_scaled_font", libcairo.}
-proc getScaledFont*(cr: PContext): PScaledFont{.cdecl, 
-    importc: "cairo_get_scaled_font", libcairo.}
-proc showText*(cr: PContext, utf8: cstring){.cdecl, importc: "cairo_show_text", 
-                                       libcairo.}
-proc showGlyphs*(cr: PContext, glyphs: PGlyph, num_glyphs: int32){.cdecl, 
-    importc: "cairo_show_glyphs", libcairo.}
-proc textPath*(cr: PContext, utf8: cstring){.cdecl, importc: "cairo_text_path", 
-                                       libcairo.}
-proc glyphPath*(cr: PContext, glyphs: PGlyph, num_glyphs: int32){.cdecl, 
-    importc: "cairo_glyph_path", libcairo.}
-proc textExtents*(cr: PContext, utf8: cstring, extents: PTextExtents){.cdecl, 
-    importc: "cairo_text_extents", libcairo.}
-proc glyphExtents*(cr: PContext, glyphs: PGlyph, num_glyphs: int32, 
-                    extents: PTextExtents){.cdecl, 
-    importc: "cairo_glyph_extents", libcairo.}
-proc fontExtents*(cr: PContext, extents: PFontExtents){.cdecl, 
-    importc: "cairo_font_extents", libcairo.}
-  #* Generic identifier for a font style
-proc reference*(font_face: PFontFace): PFontFace{.cdecl, 
-    importc: "cairo_font_face_reference", libcairo.}
-proc destroy*(font_face: PFontFace){.cdecl, 
-    importc: "cairo_font_face_destroy", libcairo.}
-proc getReferenceCount*(font_face: PFontFace): int32{.cdecl, 
-    importc: "cairo_font_face_get_reference_count", libcairo.}
-proc status*(font_face: PFontFace): TStatus{.cdecl, 
-    importc: "cairo_font_face_status", libcairo.}
-proc getType*(font_face: PFontFace): TFontType{.cdecl, 
-    importc: "cairo_font_face_get_type", libcairo.}
-proc getUserData*(font_face: PFontFace, key: PUserDataKey): pointer{.
-    cdecl, importc: "cairo_font_face_get_user_data", libcairo.}
-proc setUserData*(font_face: PFontFace, key: PUserDataKey, 
-                    user_data: pointer, destroy: TDestroyFunc): TStatus{.
-    cdecl, importc: "cairo_font_face_set_user_data", libcairo.}
-  #* Portable interface to general font features
-proc scaledFontCreate*(font_face: PFontFace, font_matrix: PMatrix, 
-                         ctm: PMatrix, options: PFontOptions): PScaledFont{.
-    cdecl, importc: "cairo_scaled_font_create", libcairo.}
-proc reference*(scaled_font: PScaledFont): PScaledFont{.cdecl, 
-    importc: "cairo_scaled_font_reference", libcairo.}
-proc destroy*(scaled_font: PScaledFont){.cdecl, 
-    importc: "cairo_scaled_font_destroy", libcairo.}
-proc getReferenceCount*(scaled_font: PScaledFont): int32{.cdecl, 
-    importc: "cairo_scaled_font_get_reference_count", libcairo.}
-proc status*(scaled_font: PScaledFont): TStatus{.cdecl, 
-    importc: "cairo_scaled_font_status", libcairo.}
-proc getType*(scaled_font: PScaledFont): TFontType{.cdecl, 
-    importc: "cairo_scaled_font_get_type", libcairo.}
-proc getUserData*(scaled_font: PScaledFont, key: PUserDataKey): pointer{.
-    cdecl, importc: "cairo_scaled_font_get_user_data", libcairo.}
-proc setUserData*(scaled_font: PScaledFont, key: PUserDataKey, 
-                    user_data: pointer, destroy: TDestroyFunc): TStatus{.
-    cdecl, importc: "cairo_scaled_font_set_user_data", libcairo.}
-proc extents*(scaled_font: PScaledFont, extents: PFontExtents){.
-    cdecl, importc: "cairo_scaled_font_extents", libcairo.}
-proc textExtents*(scaled_font: PScaledFont, utf8: cstring, 
-                   extents: PTextExtents){.cdecl, 
-    importc: "cairo_scaled_font_text_extents", libcairo.}
-proc glyphExtents*(scaled_font: PScaledFont, glyphs: PGlyph, 
-                                num_glyphs: int32, extents: PTextExtents){.
-    cdecl, importc: "cairo_scaled_font_glyph_extents", libcairo.}
-proc getFontFace*(scaled_font: PScaledFont): PFontFace{.cdecl, 
-    importc: "cairo_scaled_font_get_font_face", libcairo.}
-proc getFontMatrix*(scaled_font: PScaledFont, font_matrix: PMatrix){.
-    cdecl, importc: "cairo_scaled_font_get_font_matrix", libcairo.}
-proc getCtm*(scaled_font: PScaledFont, ctm: PMatrix){.cdecl, 
-    importc: "cairo_scaled_font_get_ctm", libcairo.}
-proc getFontOptions*(scaled_font: PScaledFont, 
-                                   options: PFontOptions){.cdecl, 
-    importc: "cairo_scaled_font_get_font_options", libcairo.}
-  #* Query functions
-proc getOperator*(cr: PContext): TOperator{.cdecl, importc: "cairo_get_operator", 
-                                      libcairo.}
-proc getSource*(cr: PContext): PPattern{.cdecl, importc: "cairo_get_source", 
-                                   libcairo.}
-proc getTolerance*(cr: PContext): float64{.cdecl, importc: "cairo_get_tolerance", 
-                                     libcairo.}
-proc getAntialias*(cr: PContext): TAntialias{.cdecl, importc: "cairo_get_antialias", 
-                                        libcairo.}
-proc getCurrentPoint*(cr: PContext, x, y: var float64){.cdecl, 
-    importc: "cairo_get_current_point", libcairo.}
-proc getFillRule*(cr: PContext): TFillRule{.cdecl, importc: "cairo_get_fill_rule", 
-                                       libcairo.}
-proc getLineWidth*(cr: PContext): float64{.cdecl, importc: "cairo_get_line_width", 
-                                      libcairo.}
-proc getLineCap*(cr: PContext): TLineCap{.cdecl, importc: "cairo_get_line_cap", 
-                                     libcairo.}
-proc getLineJoin*(cr: PContext): TLineJoin{.cdecl, importc: "cairo_get_line_join", 
-                                       libcairo.}
-proc getMiterLimit*(cr: PContext): float64{.cdecl, importc: "cairo_get_miter_limit", 
-                                       libcairo.}
-proc getDashCount*(cr: PContext): int32{.cdecl, importc: "cairo_get_dash_count", 
-                                    libcairo.}
-proc getDash*(cr: PContext, dashes, offset: var float64){.cdecl, 
-    importc: "cairo_get_dash", libcairo.}
-proc getMatrix*(cr: PContext, matrix: PMatrix){.cdecl, importc: "cairo_get_matrix", 
-    libcairo.}
-proc getTarget*(cr: PContext): PSurface{.cdecl, importc: "cairo_get_target", 
-                                   libcairo.}
-proc getGroupTarget*(cr: PContext): PSurface{.cdecl, 
-    importc: "cairo_get_group_target", libcairo.}
-proc copyPath*(cr: PContext): PPath{.cdecl, importc: "cairo_copy_path", 
-                               libcairo.}
-proc copyPathFlat*(cr: PContext): PPath{.cdecl, importc: "cairo_copy_path_flat", 
-                                    libcairo.}
-proc appendPath*(cr: PContext, path: PPath){.cdecl, importc: "cairo_append_path", 
-                                       libcairo.}
-proc destroy*(path: PPath){.cdecl, importc: "cairo_path_destroy", 
-                                 libcairo.}
-  #* Error status queries
-proc status*(cr: PContext): TStatus{.cdecl, importc: "cairo_status", libcairo.}
-proc statusToString*(status: TStatus): cstring{.cdecl, 
-    importc: "cairo_status_to_string", libcairo.}
-  #* Surface manipulation
-proc surfaceCreateSimilar*(other: PSurface, content: TContent, 
-                             width, height: int32): PSurface{.cdecl, 
-    importc: "cairo_surface_create_similar", libcairo.}
-proc reference*(surface: PSurface): PSurface{.cdecl, 
-    importc: "cairo_surface_reference", libcairo.}
-proc finish*(surface: PSurface){.cdecl, importc: "cairo_surface_finish", 
-    libcairo.}
-proc destroy*(surface: PSurface){.cdecl, 
-    importc: "cairo_surface_destroy", libcairo.}
-proc getReferenceCount*(surface: PSurface): int32{.cdecl, 
-    importc: "cairo_surface_get_reference_count", libcairo.}
-proc status*(surface: PSurface): TStatus{.cdecl, 
-    importc: "cairo_surface_status", libcairo.}
-proc getType*(surface: PSurface): TSurfaceType{.cdecl, 
-    importc: "cairo_surface_get_type", libcairo.}
-proc getContent*(surface: PSurface): TContent{.cdecl, 
-    importc: "cairo_surface_get_content", libcairo.}
-proc writeToPng*(surface: PSurface, filename: cstring): TStatus{.
-    cdecl, importc: "cairo_surface_write_to_png", libcairo.}
-proc writeToPng*(surface: PSurface, write_func: TWriteFunc, 
-                   closure: pointer): TStatus{.cdecl, 
-    importc: "cairo_surface_write_to_png_stream", libcairo.}
-proc getUserData*(surface: PSurface, key: PUserDataKey): pointer{.
-    cdecl, importc: "cairo_surface_get_user_data", libcairo.}
-proc setUserData*(surface: PSurface, key: PUserDataKey, 
-                            user_data: pointer, destroy: TDestroyFunc): TStatus{.
-    cdecl, importc: "cairo_surface_set_user_data", libcairo.}
-proc getFontOptions*(surface: PSurface, options: PFontOptions){.cdecl, 
-    importc: "cairo_surface_get_font_options", libcairo.}
-proc flush*(surface: PSurface){.cdecl, importc: "cairo_surface_flush", 
-                                        libcairo.}
-proc markDirty*(surface: PSurface){.cdecl, 
-    importc: "cairo_surface_mark_dirty", libcairo.}
-proc markDirtyRectangle*(surface: PSurface, x, y, width, height: int32){.
-    cdecl, importc: "cairo_surface_mark_dirty_rectangle", libcairo.}
-proc setDeviceOffset*(surface: PSurface, x_offset, y_offset: float64){.
-    cdecl, importc: "cairo_surface_set_device_offset", libcairo.}
-proc getDeviceOffset*(surface: PSurface, 
-                                x_offset, y_offset: var float64){.cdecl, 
-    importc: "cairo_surface_get_device_offset", libcairo.}
-proc setFallbackResolution*(surface: PSurface, x_pixels_per_inch, 
-    y_pixels_per_inch: float64){.cdecl, importc: "cairo_surface_set_fallback_resolution", 
-                                 libcairo.}
-  #* Image-surface functions
-proc imageSurfaceCreate*(format: TFormat, width, height: int32): PSurface{.
-    cdecl, importc: "cairo_image_surface_create", libcairo.}
-proc imageSurfaceCreate*(data: Pbyte, format: TFormat, 
-                           width, height, stride: int32): PSurface{.
-    cdecl, importc: "cairo_image_surface_create_for_data", libcairo.}
-proc getData*(surface: PSurface): cstring{.cdecl, 
-    importc: "cairo_image_surface_get_data", libcairo.}
-proc getFormat*(surface: PSurface): TFormat{.cdecl, 
-    importc: "cairo_image_surface_get_format", libcairo.}
-proc getWidth*(surface: PSurface): int32{.cdecl, 
-    importc: "cairo_image_surface_get_width", libcairo.}
-proc getHeight*(surface: PSurface): int32{.cdecl, 
-    importc: "cairo_image_surface_get_height", libcairo.}
-proc getStride*(surface: PSurface): int32{.cdecl, 
-    importc: "cairo_image_surface_get_stride", libcairo.}
-proc imageSurfaceCreateFromPng*(filename: cstring): PSurface{.cdecl, 
-    importc: "cairo_image_surface_create_from_png", libcairo.}
-proc imageSurfaceCreateFromPng*(read_func: TReadFunc, 
-    closure: pointer): PSurface{.cdecl, importc: "cairo_image_surface_create_from_png_stream", 
-                                 libcairo.}
-  #* Pattern creation functions
-proc patternCreateRgb*(red, green, blue: float64): PPattern{.cdecl, 
-    importc: "cairo_pattern_create_rgb", libcairo.}
-proc patternCreateRgba*(red, green, blue, alpha: float64): PPattern{.cdecl, 
-    importc: "cairo_pattern_create_rgba", libcairo.}
-proc patternCreateForSurface*(surface: PSurface): PPattern{.cdecl, 
-    importc: "cairo_pattern_create_for_surface", libcairo.}
-proc patternCreateLinear*(x0, y0, x1, y1: float64): PPattern{.cdecl, 
-    importc: "cairo_pattern_create_linear", libcairo.}
-proc patternCreateRadial*(cx0, cy0, radius0, cx1, cy1, radius1: float64): PPattern{.
-    cdecl, importc: "cairo_pattern_create_radial", libcairo.}
-proc reference*(pattern: PPattern): PPattern{.cdecl, 
-    importc: "cairo_pattern_reference", libcairo.}
-proc destroy*(pattern: PPattern){.cdecl, 
-    importc: "cairo_pattern_destroy", libcairo.}
-proc getReferenceCount*(pattern: PPattern): int32{.cdecl, 
-    importc: "cairo_pattern_get_reference_count", libcairo.}
-proc status*(pattern: PPattern): TStatus{.cdecl, 
-    importc: "cairo_pattern_status", libcairo.}
-proc getUserData*(pattern: PPattern, key: PUserDataKey): pointer{.
-    cdecl, importc: "cairo_pattern_get_user_data", libcairo.}
-proc setUserData*(pattern: PPattern, key: PUserDataKey, 
-                    user_data: pointer, destroy: TDestroyFunc): TStatus{.
-    cdecl, importc: "cairo_pattern_set_user_data", libcairo.}
-proc getType*(pattern: PPattern): TPatternType{.cdecl, 
-    importc: "cairo_pattern_get_type", libcairo.}
-proc addColorStopRgb*(pattern: PPattern, 
-                                 offset, red, green, blue: float64){.cdecl, 
-    importc: "cairo_pattern_add_color_stop_rgb", libcairo.}
-proc addColorStopRgba*(pattern: PPattern, 
-                                  offset, red, green, blue, alpha: float64){.
-    cdecl, importc: "cairo_pattern_add_color_stop_rgba", libcairo.}
-proc setMatrix*(pattern: PPattern, matrix: PMatrix){.cdecl, 
-    importc: "cairo_pattern_set_matrix", libcairo.}
-proc getMatrix*(pattern: PPattern, matrix: PMatrix){.cdecl, 
-    importc: "cairo_pattern_get_matrix", libcairo.}
-proc setExtend*(pattern: PPattern, extend: TExtend){.cdecl, 
-    importc: "cairo_pattern_set_extend", libcairo.}
-proc getExtend*(pattern: PPattern): TExtend{.cdecl, 
-    importc: "cairo_pattern_get_extend", libcairo.}
-proc setFilter*(pattern: PPattern, filter: TFilter){.cdecl, 
-    importc: "cairo_pattern_set_filter", libcairo.}
-proc getFilter*(pattern: PPattern): TFilter{.cdecl, 
-    importc: "cairo_pattern_get_filter", libcairo.}
-proc getRgba*(pattern: PPattern, 
-               red, green, blue, alpha: var float64): TStatus{.
-    cdecl, importc: "cairo_pattern_get_rgba", libcairo.}
-proc getSurface*(pattern: PPattern, surface: PPSurface): TStatus{.
-    cdecl, importc: "cairo_pattern_get_surface", libcairo.}
-proc getColorStopRgba*(pattern: PPattern, index: int32, 
-                       offset, red, green, blue, alpha: var float64): TStatus{.
-    cdecl, importc: "cairo_pattern_get_color_stop_rgba", libcairo.}
-proc getColorStopCount*(pattern: PPattern, count: var int32): TStatus{.
-    cdecl, importc: "cairo_pattern_get_color_stop_count", libcairo.}
-proc getLinearPoints*(pattern: PPattern, 
-                        x0, y0, x1, y1: var float64): TStatus{.
-    cdecl, importc: "cairo_pattern_get_linear_points", libcairo.}
-proc getRadialCircles*(pattern: PPattern, 
-                         x0, y0, r0, x1, y1, r1: var float64): TStatus{.
-    cdecl, importc: "cairo_pattern_get_radial_circles", libcairo.}
-  #* Matrix functions
-proc init*(matrix: PMatrix, xx, yx, xy, yy, x0, y0: float64){.cdecl, 
-    importc: "cairo_matrix_init", libcairo.}
-proc initIdentity*(matrix: PMatrix){.cdecl, 
-    importc: "cairo_matrix_init_identity", libcairo.}
-proc initTranslate*(matrix: PMatrix, tx, ty: float64){.cdecl, 
-    importc: "cairo_matrix_init_translate", libcairo.}
-proc initScale*(matrix: PMatrix, sx, sy: float64){.cdecl, 
-    importc: "cairo_matrix_init_scale", libcairo.}
-proc initRotate*(matrix: PMatrix, radians: float64){.cdecl, 
-    importc: "cairo_matrix_init_rotate", libcairo.}
-proc translate*(matrix: PMatrix, tx, ty: float64){.cdecl, 
-    importc: "cairo_matrix_translate", libcairo.}
-proc scale*(matrix: PMatrix, sx, sy: float64){.cdecl, 
-    importc: "cairo_matrix_scale", libcairo.}
-proc rotate*(matrix: PMatrix, radians: float64){.cdecl, 
-    importc: "cairo_matrix_rotate", libcairo.}
-proc invert*(matrix: PMatrix): TStatus{.cdecl, 
-    importc: "cairo_matrix_invert", libcairo.}
-proc multiply*(result, a, b: PMatrix){.cdecl, 
-    importc: "cairo_matrix_multiply", libcairo.}
-proc transformDistance*(matrix: PMatrix, dx, dy: var float64){.cdecl, 
-    importc: "cairo_matrix_transform_distance", libcairo.}
-proc transformPoint*(matrix: PMatrix, x, y: var float64){.cdecl, 
-    importc: "cairo_matrix_transform_point", libcairo.}
-  #* PDF functions
-proc pdfSurfaceCreate*(filename: cstring, 
-                         width_in_points, height_in_points: float64): PSurface{.
-    cdecl, importc: "cairo_pdf_surface_create", libcairo.}
-proc pdfSurfaceCreateForStream*(write_func: TWriteFunc, closure: pointer, 
-                                    width_in_points, height_in_points: float64): PSurface{.
-    cdecl, importc: "cairo_pdf_surface_create_for_stream", libcairo.}
-proc pdfSurfaceSetSize*(surface: PSurface, 
-                           width_in_points, height_in_points: float64){.cdecl, 
-    importc: "cairo_pdf_surface_set_size", libcairo.}
-  #* PS functions
-proc psSurfaceCreate*(filename: cstring, 
-                        width_in_points, height_in_points: float64): PSurface{.
-    cdecl, importc: "cairo_ps_surface_create", libcairo.}
-proc psSurfaceCreateForStream*(write_func: TWriteFunc, closure: pointer, 
-                                   width_in_points, height_in_points: float64): PSurface{.
-    cdecl, importc: "cairo_ps_surface_create_for_stream", libcairo.}
-proc psSurfaceSetSize*(surface: PSurface, 
-                          width_in_points, height_in_points: float64){.cdecl, 
-    importc: "cairo_ps_surface_set_size", libcairo.}
-proc psSurfaceDscComment*(surface: PSurface, comment: cstring){.cdecl, 
-    importc: "cairo_ps_surface_dsc_comment", libcairo.}
-proc psSurfaceDscBeginSetup*(surface: PSurface){.cdecl, 
-    importc: "cairo_ps_surface_dsc_begin_setup", libcairo.}
-proc psSurfaceDscBeginPageSetup*(surface: PSurface){.cdecl, 
-    importc: "cairo_ps_surface_dsc_begin_page_setup", libcairo.}
-  #* SVG functions
-proc svgSurfaceCreate*(filename: cstring, 
-                         width_in_points, height_in_points: float64): PSurface{.
-    cdecl, importc: "cairo_svg_surface_create", libcairo.}
-proc svgSurfaceCreateForStream*(write_func: TWriteFunc, closure: pointer, 
-                                    width_in_points, height_in_points: float64): PSurface{.
-    cdecl, importc: "cairo_svg_surface_create_for_stream", libcairo.}
-proc svgSurfaceRestrictToVersion*(surface: PSurface, version: TSvgVersion){.
-    cdecl, importc: "cairo_svg_surface_restrict_to_version", libcairo.}
+proc selectFontFace*(cr: PContext, family: cstring, slant: TFontSlant, weight: TFontWeight) {.importc: "cairo_select_font_face".}
+proc setFontSize*(cr: PContext, size: float64) {.importc: "cairo_set_font_size".}
+proc setFontMatrix*(cr: PContext, matrix: PMatrix) {.importc: "cairo_set_font_matrix".}
+proc getFontMatrix*(cr: PContext, matrix: PMatrix) {.importc: "cairo_get_font_matrix".}
+proc setFontOptions*(cr: PContext, options: PFontOptions) {.importc: "cairo_set_font_options".}
+proc getFontOptions*(cr: PContext, options: PFontOptions) {.importc: "cairo_get_font_options".}
+proc setFontFace*(cr: PContext, font_face: PFontFace) {.importc: "cairo_set_font_face".}
+proc getFontFace*(cr: PContext): PFontFace {.importc: "cairo_get_font_face".}
+proc setScaledFont*(cr: PContext, scaled_font: PScaledFont) {.importc: "cairo_set_scaled_font".}
+proc getScaledFont*(cr: PContext): PScaledFont {.importc: "cairo_get_scaled_font".}
+proc showText*(cr: PContext, utf8: cstring) {.importc: "cairo_show_text".}
+proc showGlyphs*(cr: PContext, glyphs: PGlyph, num_glyphs: int32) {.importc: "cairo_show_glyphs".}
+proc textPath*(cr: PContext, utf8: cstring) {.importc: "cairo_text_path".}
+proc glyphPath*(cr: PContext, glyphs: PGlyph, num_glyphs: int32) {.importc: "cairo_glyph_path".}
+proc textExtents*(cr: PContext, utf8: cstring, extents: PTextExtents) {.importc: "cairo_text_extents".}
+proc glyphExtents*(cr: PContext, glyphs: PGlyph, num_glyphs: int32, extents: PTextExtents) {.importc: "cairo_glyph_extents".}
+proc fontExtents*(cr: PContext, extents: PFontExtents) {.importc: "cairo_font_extents".}
+# Generic identifier for a font style
+proc reference*(font_face: PFontFace): PFontFace {.importc: "cairo_font_face_reference".}
+proc destroy*(font_face: PFontFace) {.importc: "cairo_font_face_destroy".}
+proc getReferenceCount*(font_face: PFontFace): int32 {.importc: "cairo_font_face_get_reference_count".}
+proc status*(font_face: PFontFace): TStatus {.importc: "cairo_font_face_status".}
+proc getType*(font_face: PFontFace): TFontType {.importc: "cairo_font_face_get_type".}
+proc getUserData*(font_face: PFontFace, key: PUserDataKey): pointer{. cdecl, importc: "cairo_font_face_get_user_data".}
+proc setUserData*(font_face: PFontFace, key: PUserDataKey, user_data: pointer, destroy: TDestroyFunc): TStatus{. cdecl, importc: "cairo_font_face_set_user_data".}
+# Portable interface to general font features
+proc scaledFontCreate*(font_face: PFontFace, font_matrix: PMatrix, ctm: PMatrix, options: PFontOptions): PScaledFont{. cdecl, importc: "cairo_scaled_font_create".}
+proc reference*(scaled_font: PScaledFont): PScaledFont {.importc: "cairo_scaled_font_reference".}
+proc destroy*(scaled_font: PScaledFont) {.importc: "cairo_scaled_font_destroy".}
+proc getReferenceCount*(scaled_font: PScaledFont): int32 {.importc: "cairo_scaled_font_get_reference_count".}
+proc status*(scaled_font: PScaledFont): TStatus {.importc: "cairo_scaled_font_status".}
+proc getType*(scaled_font: PScaledFont): TFontType {.importc: "cairo_scaled_font_get_type".}
+proc getUserData*(scaled_font: PScaledFont, key: PUserDataKey): pointer{. cdecl, importc: "cairo_scaled_font_get_user_data".}
+proc setUserData*(scaled_font: PScaledFont, key: PUserDataKey, user_data: pointer, destroy: TDestroyFunc): TStatus{. cdecl, importc: "cairo_scaled_font_set_user_data".}
+proc extents*(scaled_font: PScaledFont, extents: PFontExtents){. cdecl, importc: "cairo_scaled_font_extents".}
+proc textExtents*(scaled_font: PScaledFont, utf8: cstring, extents: PTextExtents) {.importc: "cairo_scaled_font_text_extents".}
+proc glyphExtents*(scaled_font: PScaledFont, glyphs: PGlyph, num_glyphs: int32, extents: PTextExtents){. cdecl, importc: "cairo_scaled_font_glyph_extents".}
+proc getFontFace*(scaled_font: PScaledFont): PFontFace {.importc: "cairo_scaled_font_get_font_face".}
+proc getFontMatrix*(scaled_font: PScaledFont, font_matrix: PMatrix){. cdecl, importc: "cairo_scaled_font_get_font_matrix".}
+proc getCtm*(scaled_font: PScaledFont, ctm: PMatrix) {.importc: "cairo_scaled_font_get_ctm".}
+proc getFontOptions*(scaled_font: PScaledFont, options: PFontOptions) {.importc: "cairo_scaled_font_get_font_options".}
+# Query functions
+proc getOperator*(cr: PContext): TOperator {.importc: "cairo_get_operator".}
+proc getSource*(cr: PContext): PPattern {.importc: "cairo_get_source".}
+proc getTolerance*(cr: PContext): float64 {.importc: "cairo_get_tolerance".}
+proc getAntialias*(cr: PContext): TAntialias {.importc: "cairo_get_antialias".}
+proc getCurrentPoint*(cr: PContext, x, y: var float64) {.importc: "cairo_get_current_point".}
+proc getFillRule*(cr: PContext): TFillRule {.importc: "cairo_get_fill_rule".}
+proc getLineWidth*(cr: PContext): float64 {.importc: "cairo_get_line_width".}
+proc getLineCap*(cr: PContext): TLineCap {.importc: "cairo_get_line_cap".}
+proc getLineJoin*(cr: PContext): TLineJoin {.importc: "cairo_get_line_join".}
+proc getMiterLimit*(cr: PContext): float64 {.importc: "cairo_get_miter_limit".}
+proc getDashCount*(cr: PContext): int32 {.importc: "cairo_get_dash_count".}
+proc getDash*(cr: PContext, dashes, offset: var float64) {.importc: "cairo_get_dash".}
+proc getMatrix*(cr: PContext, matrix: PMatrix) {.importc: "cairo_get_matrix".}
+proc getTarget*(cr: PContext): PSurface {.importc: "cairo_get_target".}
+proc getGroupTarget*(cr: PContext): PSurface {.importc: "cairo_get_group_target".}
+proc copyPath*(cr: PContext): PPath {.importc: "cairo_copy_path".}
+proc copyPathFlat*(cr: PContext): PPath {.importc: "cairo_copy_path_flat".}
+proc appendPath*(cr: PContext, path: PPath) {.importc: "cairo_append_path".}
+proc destroy*(path: PPath) {.importc: "cairo_path_destroy".}
+# Error status queries
+proc status*(cr: PContext): TStatus {.importc: "cairo_status".}
+proc statusToString*(status: TStatus): cstring {.importc: "cairo_status_to_string".}
+# Surface manipulation
+proc surfaceCreateSimilar*(other: PSurface, content: TContent, width, height: int32): PSurface {.importc: "cairo_surface_create_similar".}
+proc reference*(surface: PSurface): PSurface {.importc: "cairo_surface_reference".}
+proc finish*(surface: PSurface) {.importc: "cairo_surface_finish".}
+proc destroy*(surface: PSurface) {.importc: "cairo_surface_destroy".}
+proc getReferenceCount*(surface: PSurface): int32 {.importc: "cairo_surface_get_reference_count".}
+proc status*(surface: PSurface): TStatus {.importc: "cairo_surface_status".}
+proc getType*(surface: PSurface): TSurfaceType {.importc: "cairo_surface_get_type".}
+proc getContent*(surface: PSurface): TContent {.importc: "cairo_surface_get_content".}
+proc writeToPng*(surface: PSurface, filename: cstring): TStatus{. cdecl, importc: "cairo_surface_write_to_png".}
+proc writeToPng*(surface: PSurface, write_func: TWriteFunc, closure: pointer): TStatus {.importc: "cairo_surface_write_to_png_stream".}
+proc getUserData*(surface: PSurface, key: PUserDataKey): pointer{. cdecl, importc: "cairo_surface_get_user_data".}
+proc setUserData*(surface: PSurface, key: PUserDataKey, user_data: pointer, destroy: TDestroyFunc): TStatus{. cdecl, importc: "cairo_surface_set_user_data".}
+proc getFontOptions*(surface: PSurface, options: PFontOptions) {.importc: "cairo_surface_get_font_options".}
+proc flush*(surface: PSurface) {.importc: "cairo_surface_flush".}
+proc markDirty*(surface: PSurface) {.importc: "cairo_surface_mark_dirty".}
+proc markDirtyRectangle*(surface: PSurface, x, y, width, height: int32){. cdecl, importc: "cairo_surface_mark_dirty_rectangle".}
+proc setDeviceOffset*(surface: PSurface, x_offset, y_offset: float64){. cdecl, importc: "cairo_surface_set_device_offset".}
+proc getDeviceOffset*(surface: PSurface, x_offset, y_offset: var float64) {.importc: "cairo_surface_get_device_offset".}
+proc setFallbackResolution*(surface: PSurface, x_pixels_per_inch, y_pixels_per_inch: float64) {.importc: "cairo_surface_set_fallback_resolution".}
+# Image-surface functions
+proc imageSurfaceCreate*(format: TFormat, width, height: int32): PSurface{. cdecl, importc: "cairo_image_surface_create".}
+proc imageSurfaceCreate*(data: Pbyte, format: TFormat, width, height, stride: int32): PSurface{. cdecl, importc: "cairo_image_surface_create_for_data".}
+proc getData*(surface: PSurface): cstring {.importc: "cairo_image_surface_get_data".}
+proc getFormat*(surface: PSurface): TFormat {.importc: "cairo_image_surface_get_format".}
+proc getWidth*(surface: PSurface): int32 {.importc: "cairo_image_surface_get_width".}
+proc getHeight*(surface: PSurface): int32 {.importc: "cairo_image_surface_get_height".}
+proc getStride*(surface: PSurface): int32 {.importc: "cairo_image_surface_get_stride".}
+proc imageSurfaceCreateFromPng*(filename: cstring): PSurface {.importc: "cairo_image_surface_create_from_png".}
+proc imageSurfaceCreateFromPng*(read_func: TReadFunc, closure: pointer): PSurface {.importc: "cairo_image_surface_create_from_png_stream".}
+# Pattern creation functions
+proc patternCreateRgb*(red, green, blue: float64): PPattern {.importc: "cairo_pattern_create_rgb".}
+proc patternCreateRgba*(red, green, blue, alpha: float64): PPattern {.importc: "cairo_pattern_create_rgba".}
+proc patternCreateForSurface*(surface: PSurface): PPattern {.importc: "cairo_pattern_create_for_surface".}
+proc patternCreateLinear*(x0, y0, x1, y1: float64): PPattern {.importc: "cairo_pattern_create_linear".}
+proc patternCreateRadial*(cx0, cy0, radius0, cx1, cy1, radius1: float64): PPattern{. cdecl, importc: "cairo_pattern_create_radial".}
+proc reference*(pattern: PPattern): PPattern {.importc: "cairo_pattern_reference".}
+proc destroy*(pattern: PPattern) {.importc: "cairo_pattern_destroy".}
+proc getReferenceCount*(pattern: PPattern): int32 {.importc: "cairo_pattern_get_reference_count".}
+proc status*(pattern: PPattern): TStatus {.importc: "cairo_pattern_status".}
+proc getUserData*(pattern: PPattern, key: PUserDataKey): pointer{. cdecl, importc: "cairo_pattern_get_user_data".}
+proc setUserData*(pattern: PPattern, key: PUserDataKey, user_data: pointer, destroy: TDestroyFunc): TStatus{. cdecl, importc: "cairo_pattern_set_user_data".}
+proc getType*(pattern: PPattern): TPatternType {.importc: "cairo_pattern_get_type".}
+proc addColorStopRgb*(pattern: PPattern, offset, red, green, blue: float64) {.importc: "cairo_pattern_add_color_stop_rgb".}
+proc addColorStopRgba*(pattern: PPattern, offset, red, green, blue, alpha: float64){. cdecl, importc: "cairo_pattern_add_color_stop_rgba".}
+proc setMatrix*(pattern: PPattern, matrix: PMatrix) {.importc: "cairo_pattern_set_matrix".}
+proc getMatrix*(pattern: PPattern, matrix: PMatrix) {.importc: "cairo_pattern_get_matrix".}
+proc setExtend*(pattern: PPattern, extend: TExtend) {.importc: "cairo_pattern_set_extend".}
+proc getExtend*(pattern: PPattern): TExtend {.importc: "cairo_pattern_get_extend".}
+proc setFilter*(pattern: PPattern, filter: TFilter) {.importc: "cairo_pattern_set_filter".}
+proc getFilter*(pattern: PPattern): TFilter {.importc: "cairo_pattern_get_filter".}
+proc getRgba*(pattern: PPattern, red, green, blue, alpha: var float64): TStatus{. cdecl, importc: "cairo_pattern_get_rgba".}
+proc getSurface*(pattern: PPattern, surface: PPSurface): TStatus{. cdecl, importc: "cairo_pattern_get_surface".}
+proc getColorStopRgba*(pattern: PPattern, index: int32, offset, red, green, blue, alpha: var float64): TStatus{. cdecl, importc: "cairo_pattern_get_color_stop_rgba".}
+proc getColorStopCount*(pattern: PPattern, count: var int32): TStatus{. cdecl, importc: "cairo_pattern_get_color_stop_count".}
+proc getLinearPoints*(pattern: PPattern, x0, y0, x1, y1: var float64): TStatus{. cdecl, importc: "cairo_pattern_get_linear_points".}
+proc getRadialCircles*(pattern: PPattern, x0, y0, r0, x1, y1, r1: var float64): TStatus{. cdecl, importc: "cairo_pattern_get_radial_circles".}
+# Matrix functions
+proc init*(matrix: PMatrix, xx, yx, xy, yy, x0, y0: float64) {.importc: "cairo_matrix_init".}
+proc initIdentity*(matrix: PMatrix) {.importc: "cairo_matrix_init_identity".}
+proc initTranslate*(matrix: PMatrix, tx, ty: float64) {.importc: "cairo_matrix_init_translate".}
+proc initScale*(matrix: PMatrix, sx, sy: float64) {.importc: "cairo_matrix_init_scale".}
+proc initRotate*(matrix: PMatrix, radians: float64) {.importc: "cairo_matrix_init_rotate".}
+proc translate*(matrix: PMatrix, tx, ty: float64) {.importc: "cairo_matrix_translate".}
+proc scale*(matrix: PMatrix, sx, sy: float64) {.importc: "cairo_matrix_scale".}
+proc rotate*(matrix: PMatrix, radians: float64) {.importc: "cairo_matrix_rotate".}
+proc invert*(matrix: PMatrix): TStatus {.importc: "cairo_matrix_invert".}
+proc multiply*(result, a, b: PMatrix) {.importc: "cairo_matrix_multiply".}
+proc transformDistance*(matrix: PMatrix, dx, dy: var float64) {.importc: "cairo_matrix_transform_distance".}
+proc transformPoint*(matrix: PMatrix, x, y: var float64) {.importc: "cairo_matrix_transform_point".}
+# PDF functions
+proc pdfSurfaceCreate*(filename: cstring, width_in_points, height_in_points: float64): PSurface{. cdecl, importc: "cairo_pdf_surface_create".}
+proc pdfSurfaceCreateForStream*(write_func: TWriteFunc, closure: pointer, width_in_points, height_in_points: float64): PSurface{. cdecl, importc: "cairo_pdf_surface_create_for_stream".}
+proc pdfSurfaceSetSize*(surface: PSurface, width_in_points, height_in_points: float64) {.importc: "cairo_pdf_surface_set_size".}
+# PS functions
+proc psSurfaceCreate*(filename: cstring, width_in_points, height_in_points: float64): PSurface{. cdecl, importc: "cairo_ps_surface_create".}
+proc psSurfaceCreateForStream*(write_func: TWriteFunc, closure: pointer, width_in_points, height_in_points: float64): PSurface{. cdecl, importc: "cairo_ps_surface_create_for_stream".}
+proc psSurfaceSetSize*(surface: PSurface, width_in_points, height_in_points: float64) {.importc: "cairo_ps_surface_set_size".}
+proc psSurfaceDscComment*(surface: PSurface, comment: cstring) {.importc: "cairo_ps_surface_dsc_comment".}
+proc psSurfaceDscBeginSetup*(surface: PSurface) {.importc: "cairo_ps_surface_dsc_begin_setup".}
+proc psSurfaceDscBeginPageSetup*(surface: PSurface) {.importc: "cairo_ps_surface_dsc_begin_page_setup".}
+# SVG functions
+proc svgSurfaceCreate*(filename: cstring, width_in_points, height_in_points: float64): PSurface{. cdecl, importc: "cairo_svg_surface_create".}
+proc svgSurfaceCreateForStream*(write_func: TWriteFunc, closure: pointer, width_in_points, height_in_points: float64): PSurface{. cdecl, importc: "cairo_svg_surface_create_for_stream".}
+proc svgSurfaceRestrictToVersion*(surface: PSurface, version: TSvgVersion){. cdecl, importc: "cairo_svg_surface_restrict_to_version".}
   #todo: see how translate this
-  #procedure cairo_svg_get_versions(TCairoSvgVersion const	**versions,
-  #                        int                      	 *num_versions);
-proc svgVersionToString*(version: TSvgVersion): cstring{.cdecl, 
-    importc: "cairo_svg_version_to_string", libcairo.}
-  #* Functions to be used while debugging (not intended for use in production code)
-proc debugResetStaticData*(){.cdecl, 
-                                 importc: "cairo_debug_reset_static_data", 
-                                 libcairo.}
+  #procedure cairo_svg_get_versions(TCairoSvgVersion const **versions, # int *num_versions); proc svgVersionToString*(version: TSvgVersion): cstring {.importc: "cairo_svg_version_to_string".}
+# Functions to be used while debugging (not intended for use in production code)
+proc debugResetStaticData*() {.importc: "cairo_debug_reset_static_data".}
+
+# new since 1.10
+proc surfaceCreateForRectangle*(target: PSurface, x,y,w,h: cdouble): PSurface  {.importc: "cairo_surface_create_for_rectangle".}
+
+{.pop.}
+
 # implementation
 
-proc version(major, minor, micro: var int32) = 
+proc version*(major, minor, micro: var int32) =
   var version: int32
   version = version()
   major = version div 10000'i32
   minor = (version mod (major * 10000'i32)) div 100'i32
   micro = (version mod ((major * 10000'i32) + (minor * 100'i32)))
-  
-proc checkStatus*(s: cairo.TStatus) {.noinline.} = 
+
+proc checkStatus*(s: cairo.TStatus) {.noinline.} =
   ## if ``s != StatusSuccess`` the error is turned into an appropirate Nimrod
   ## exception and raised.
   case s
   of StatusSuccess: discard
-  of StatusNoMemory: 
+  of StatusNoMemory:
     raise newException(OutOfMemError, $statusToString(s))
-  of STATUS_READ_ERROR, STATUS_WRITE_ERROR, STATUS_FILE_NOT_FOUND, 
+  of STATUS_READ_ERROR, STATUS_WRITE_ERROR, STATUS_FILE_NOT_FOUND,
      STATUS_TEMP_FILE_ERROR:
     raise newException(IOError, $statusToString(s))
   else:
     raise newException(AssertionError, $statusToString(s))
-
-
-# new since 1.10
-proc surfaceCreateForRectangle*(target: PSurface, x,y,w,h: cdouble):
-    PSurface {.cdecl, importc: "cairo_surface_create_for_rectangle", libcairo.}
 

--- a/src/cairo_pragma.nim
+++ b/src/cairo_pragma.nim
@@ -1,16 +1,16 @@
 # included by cairo bindings
 
 when declared(use_pkg_config) or declared(use_pkg_config_static):
-    {.pragma: libcairo, cdecl.}
-    when defined(use_pkg_config_static):
-        {.passl: gorge("pkg-config cairo --libs --static").}
-    else:
-        {.passl: gorge("pkg-config cairo --libs").}
+  {.pragma: libcairo, cdecl.}
+  when defined(use_pkg_config_static):
+    {.passl: gorge("pkg-config cairo --libs --static").}
+  else:
+    {.passl: gorge("pkg-config cairo --libs").}
 else:
-    when defined(windows): 
-      const LIB_CAIRO* = "libcairo-2.dll"
-    elif defined(macosx):
-      const LIB_CAIRO* = "libcairo(|.2).dylib"
-    else: 
-      const LIB_CAIRO* = "libcairo.so(|.2)"
-    {.pragma: libcairo, cdecl, dynlib: LIB_CAIRO.}
+  when defined(windows):
+    const LIB_CAIRO* = "libcairo-2.dll"
+  elif defined(macosx):
+    const LIB_CAIRO* = "libcairo(|.2).dylib"
+  else:
+    const LIB_CAIRO* = "libcairo.so(|.2)"
+  {.pragma: libcairo, cdecl, dynlib: LIB_CAIRO.}

--- a/src/cairoft.nim
+++ b/src/cairoft.nim
@@ -1,10 +1,10 @@
 #
-# Translation of cairo-ft.h 
-# by Jeffrey Pohlmeyer 
-# updated to version 1.4 by Luiz Américo Pereira Câmara 2007
+# Translation of cairo-ft.h
+# by Jeffrey Pohlmeyer
+# updated to version 1.4 by Luiz Amï¿½rico Pereira Cï¿½mara 2007
 #
 
-import 
+import
   cairo, freetypeh
 
 include "cairo_pragma.nim"
@@ -20,12 +20,12 @@ include "cairo_pragma.nim"
 # typedef FcPattern XftPattern;
 #
 
-type 
-  FcPattern* = Pointer
+type
+  FcPattern* = pointer
   PFcPattern* = ptr FcPattern
 
-proc ftFontFaceCreateForPattern*(pattern: PFcPattern): PFontFace{.libcairo, importc: "cairo_ft_font_face_create_for_pattern".}
+proc ftFontFaceCreateForPattern*(pattern: PFcPattern): PFontFace {.libcairo, importc: "cairo_ft_font_face_create_for_pattern".}
 proc ftFontOptionsSubstitute*(options: PFontOptions, pattern: PFcPattern){. libcairo, importc: "cairo_ft_font_options_substitute".}
-proc ftFontFaceCreateForFtFace*(face: TFT_Face, load_flags: int32): PFontFace{.libcairo, importc: "cairo_ft_font_face_create_for_ft_face".}
-proc ftScaledFontLockFace*(scaled_font: PScaledFont): TFT_Face{.libcairo, importc: "cairo_ft_scaled_font_lock_face".}
-proc ftScaledFontUnlockFace*(scaled_font: PScaledFont){.libcairo, importc: "cairo_ft_scaled_font_unlock_face".}
+proc ftFontFaceCreateForFtFace*(face: TFT_Face, load_flags: int32): PFontFace {.libcairo, importc: "cairo_ft_font_face_create_for_ft_face".}
+proc ftScaledFontLockFace*(scaled_font: PScaledFont): TFT_Face {.libcairo, importc: "cairo_ft_scaled_font_lock_face".}
+proc ftScaledFontUnlockFace*(scaled_font: PScaledFont) {.libcairo, importc: "cairo_ft_scaled_font_unlock_face".}

--- a/src/cairoft.nim
+++ b/src/cairoft.nim
@@ -1,7 +1,7 @@
 #
 # Translation of cairo-ft.h
 # by Jeffrey Pohlmeyer
-# updated to version 1.4 by Luiz Am�rico Pereira C�mara 2007
+# updated to version 1.4 by Luiz Américo Pereira Câmara 2007
 #
 
 import

--- a/src/cairoft.nim
+++ b/src/cairoft.nim
@@ -24,13 +24,8 @@ type
   FcPattern* = Pointer
   PFcPattern* = ptr FcPattern
 
-proc ftFontFaceCreateForPattern*(pattern: PFcPattern): PFontFace{.libcairo,
-    importc: "cairo_ft_font_face_create_for_pattern".}
-proc ftFontOptionsSubstitute*(options: PFontOptions, pattern: PFcPattern){.
-    libcairo, importc: "cairo_ft_font_options_substitute".}
-proc ftFontFaceCreateForFtFace*(face: TFT_Face, load_flags: int32): PFontFace{.libcairo,
-    importc: "cairo_ft_font_face_create_for_ft_face".}
-proc ftScaledFontLockFace*(scaled_font: PScaledFont): TFT_Face{.libcairo,
-    importc: "cairo_ft_scaled_font_lock_face".}
-proc ftScaledFontUnlockFace*(scaled_font: PScaledFont){.libcairo,
-    importc: "cairo_ft_scaled_font_unlock_face".}
+proc ftFontFaceCreateForPattern*(pattern: PFcPattern): PFontFace{.libcairo, importc: "cairo_ft_font_face_create_for_pattern".}
+proc ftFontOptionsSubstitute*(options: PFontOptions, pattern: PFcPattern){. libcairo, importc: "cairo_ft_font_options_substitute".}
+proc ftFontFaceCreateForFtFace*(face: TFT_Face, load_flags: int32): PFontFace{.libcairo, importc: "cairo_ft_font_face_create_for_ft_face".}
+proc ftScaledFontLockFace*(scaled_font: PScaledFont): TFT_Face{.libcairo, importc: "cairo_ft_scaled_font_lock_face".}
+proc ftScaledFontUnlockFace*(scaled_font: PScaledFont){.libcairo, importc: "cairo_ft_scaled_font_unlock_face".}

--- a/src/cairowin32.nim
+++ b/src/cairowin32.nim
@@ -6,32 +6,16 @@
 import 
   cairo, windows
 
-proc win32SurfaceCreate*(hdc: HDC): PSurface{.cdecl, 
-    importc: "cairo_win32_surface_create", dynlib: LIB_CAIRO.}
-proc win32SurfaceCreateWithDdb*(hdc: HDC, format: TFormat, 
-                                    width, height: int32): PSurface{.cdecl, 
-    importc: "cairo_win32_surface_create_with_ddb", dynlib: LIB_CAIRO.}
-proc win32SurfaceCreateWithDib*(format: TFormat, width, height: int32): PSurface{.
-    cdecl, importc: "cairo_win32_surface_create_with_dib", dynlib: LIB_CAIRO.}
-proc win32SurfaceGetDc*(surface: PSurface): HDC{.cdecl, 
-    importc: "cairo_win32_surface_get_dc", dynlib: LIB_CAIRO.}
-proc win32SurfaceGetImage*(surface: PSurface): PSurface{.cdecl, 
-    importc: "cairo_win32_surface_get_image", dynlib: LIB_CAIRO.}
-proc win32FontFaceCreateForLogfontw*(logfont: PLOGFONTW): PFontFace{.cdecl, 
-    importc: "cairo_win32_font_face_create_for_logfontw", dynlib: LIB_CAIRO.}
-proc win32FontFaceCreateForHfont*(font: HFONT): PFontFace{.cdecl, 
-    importc: "cairo_win32_font_face_create_for_hfont", dynlib: LIB_CAIRO.}
-proc win32ScaledFontSelectFont*(scaled_font: PScaledFont, hdc: HDC): TStatus{.
-    cdecl, importc: "cairo_win32_scaled_font_select_font", dynlib: LIB_CAIRO.}
-proc win32ScaledFontDoneFont*(scaled_font: PScaledFont){.cdecl, 
-    importc: "cairo_win32_scaled_font_done_font", dynlib: LIB_CAIRO.}
-proc win32ScaledFontGetMetricsFactor*(scaled_font: PScaledFont): float64{.
-    cdecl, importc: "cairo_win32_scaled_font_get_metrics_factor", 
-    dynlib: LIB_CAIRO.}
-proc win32ScaledFontGetLogicalToDevice*(scaled_font: PScaledFont, 
-    logical_to_device: PMatrix){.cdecl, importc: "cairo_win32_scaled_font_get_logical_to_device", 
-                                 dynlib: LIB_CAIRO.}
-proc win32ScaledFontGetDeviceToLogical*(scaled_font: PScaledFont, 
-    device_to_logical: PMatrix){.cdecl, importc: "cairo_win32_scaled_font_get_device_to_logical", 
-                                 dynlib: LIB_CAIRO.}
+proc win32SurfaceCreate*(hdc: HDC): PSurface{.cdecl, importc: "cairo_win32_surface_create", dynlib: LIB_CAIRO.}
+proc win32SurfaceCreateWithDdb*(hdc: HDC, format: TFormat, width, height: int32): PSurface{.cdecl, importc: "cairo_win32_surface_create_with_ddb", dynlib: LIB_CAIRO.}
+proc win32SurfaceCreateWithDib*(format: TFormat, width, height: int32): PSurface{. cdecl, importc: "cairo_win32_surface_create_with_dib", dynlib: LIB_CAIRO.}
+proc win32SurfaceGetDc*(surface: PSurface): HDC{.cdecl, importc: "cairo_win32_surface_get_dc", dynlib: LIB_CAIRO.}
+proc win32SurfaceGetImage*(surface: PSurface): PSurface{.cdecl, importc: "cairo_win32_surface_get_image", dynlib: LIB_CAIRO.}
+proc win32FontFaceCreateForLogfontw*(logfont: PLOGFONTW): PFontFace{.cdecl, importc: "cairo_win32_font_face_create_for_logfontw", dynlib: LIB_CAIRO.}
+proc win32FontFaceCreateForHfont*(font: HFONT): PFontFace{.cdecl, importc: "cairo_win32_font_face_create_for_hfont", dynlib: LIB_CAIRO.}
+proc win32ScaledFontSelectFont*(scaled_font: PScaledFont, hdc: HDC): TStatus{. cdecl, importc: "cairo_win32_scaled_font_select_font", dynlib: LIB_CAIRO.}
+proc win32ScaledFontDoneFont*(scaled_font: PScaledFont){.cdecl, importc: "cairo_win32_scaled_font_done_font", dynlib: LIB_CAIRO.}
+proc win32ScaledFontGetMetricsFactor*(scaled_font: PScaledFont): float64{. cdecl, importc: "cairo_win32_scaled_font_get_metrics_factor", dynlib: LIB_CAIRO.}
+proc win32ScaledFontGetLogicalToDevice*(scaled_font: PScaledFont, logical_to_device: PMatrix){.cdecl, importc: "cairo_win32_scaled_font_get_logical_to_device", dynlib: LIB_CAIRO.}
+proc win32ScaledFontGetDeviceToLogical*(scaled_font: PScaledFont, device_to_logical: PMatrix){.cdecl, importc: "cairo_win32_scaled_font_get_device_to_logical", dynlib: LIB_CAIRO.}
 # implementation

--- a/src/cairowin32.nim
+++ b/src/cairowin32.nim
@@ -3,19 +3,19 @@
 # by Luiz Américo Pereira Câmara 2007
 #
 
-import 
+import
   cairo, windows
 
-proc win32SurfaceCreate*(hdc: HDC): PSurface{.cdecl, importc: "cairo_win32_surface_create", dynlib: LIB_CAIRO.}
-proc win32SurfaceCreateWithDdb*(hdc: HDC, format: TFormat, width, height: int32): PSurface{.cdecl, importc: "cairo_win32_surface_create_with_ddb", dynlib: LIB_CAIRO.}
+proc win32SurfaceCreate*(hdc: HDC): PSurface {.cdecl, importc: "cairo_win32_surface_create", dynlib: LIB_CAIRO.}
+proc win32SurfaceCreateWithDdb*(hdc: HDC, format: TFormat, width, height: int32): PSurface {.cdecl, importc: "cairo_win32_surface_create_with_ddb", dynlib: LIB_CAIRO.}
 proc win32SurfaceCreateWithDib*(format: TFormat, width, height: int32): PSurface{. cdecl, importc: "cairo_win32_surface_create_with_dib", dynlib: LIB_CAIRO.}
-proc win32SurfaceGetDc*(surface: PSurface): HDC{.cdecl, importc: "cairo_win32_surface_get_dc", dynlib: LIB_CAIRO.}
-proc win32SurfaceGetImage*(surface: PSurface): PSurface{.cdecl, importc: "cairo_win32_surface_get_image", dynlib: LIB_CAIRO.}
-proc win32FontFaceCreateForLogfontw*(logfont: PLOGFONTW): PFontFace{.cdecl, importc: "cairo_win32_font_face_create_for_logfontw", dynlib: LIB_CAIRO.}
-proc win32FontFaceCreateForHfont*(font: HFONT): PFontFace{.cdecl, importc: "cairo_win32_font_face_create_for_hfont", dynlib: LIB_CAIRO.}
+proc win32SurfaceGetDc*(surface: PSurface): HDC {.cdecl, importc: "cairo_win32_surface_get_dc", dynlib: LIB_CAIRO.}
+proc win32SurfaceGetImage*(surface: PSurface): PSurface {.cdecl, importc: "cairo_win32_surface_get_image", dynlib: LIB_CAIRO.}
+proc win32FontFaceCreateForLogfontw*(logfont: PLOGFONTW): PFontFace {.cdecl, importc: "cairo_win32_font_face_create_for_logfontw", dynlib: LIB_CAIRO.}
+proc win32FontFaceCreateForHfont*(font: HFONT): PFontFace {.cdecl, importc: "cairo_win32_font_face_create_for_hfont", dynlib: LIB_CAIRO.}
 proc win32ScaledFontSelectFont*(scaled_font: PScaledFont, hdc: HDC): TStatus{. cdecl, importc: "cairo_win32_scaled_font_select_font", dynlib: LIB_CAIRO.}
-proc win32ScaledFontDoneFont*(scaled_font: PScaledFont){.cdecl, importc: "cairo_win32_scaled_font_done_font", dynlib: LIB_CAIRO.}
+proc win32ScaledFontDoneFont*(scaled_font: PScaledFont) {.cdecl, importc: "cairo_win32_scaled_font_done_font", dynlib: LIB_CAIRO.}
 proc win32ScaledFontGetMetricsFactor*(scaled_font: PScaledFont): float64{. cdecl, importc: "cairo_win32_scaled_font_get_metrics_factor", dynlib: LIB_CAIRO.}
-proc win32ScaledFontGetLogicalToDevice*(scaled_font: PScaledFont, logical_to_device: PMatrix){.cdecl, importc: "cairo_win32_scaled_font_get_logical_to_device", dynlib: LIB_CAIRO.}
-proc win32ScaledFontGetDeviceToLogical*(scaled_font: PScaledFont, device_to_logical: PMatrix){.cdecl, importc: "cairo_win32_scaled_font_get_device_to_logical", dynlib: LIB_CAIRO.}
+proc win32ScaledFontGetLogicalToDevice*(scaled_font: PScaledFont, logical_to_device: PMatrix) {.cdecl, importc: "cairo_win32_scaled_font_get_logical_to_device", dynlib: LIB_CAIRO.}
+proc win32ScaledFontGetDeviceToLogical*(scaled_font: PScaledFont, device_to_logical: PMatrix) {.cdecl, importc: "cairo_win32_scaled_font_get_device_to_logical", dynlib: LIB_CAIRO.}
 # implementation

--- a/src/cairoxlib.nim
+++ b/src/cairoxlib.nim
@@ -1,7 +1,7 @@
 #
 # Translation of cairo-xlib.h version 1.4
 # by Jeffrey Pohlmeyer
-# updated to version 1.4 by Luiz Am�rico Pereira C�mara 2007
+# updated to version 1.4 by Luiz Américo Pereira Câmara 2007
 #
 
 import

--- a/src/cairoxlib.nim
+++ b/src/cairoxlib.nim
@@ -1,24 +1,24 @@
 #
 # Translation of cairo-xlib.h version 1.4
-# by Jeffrey Pohlmeyer 
-# updated to version 1.4 by Luiz Américo Pereira Câmara 2007
+# by Jeffrey Pohlmeyer
+# updated to version 1.4 by Luiz Amï¿½rico Pereira Cï¿½mara 2007
 #
 
-import 
+import
   cairo, x, xlib, xrender
 
 include "cairo_pragma.nim"
 
-proc xlibSurfaceCreate*(dpy: PDisplay, drawable: TDrawable, visual: PVisual, width, height: int32): PSurface{.cdecl, importc: "cairo_xlib_surface_create", libcairo.}
+proc xlibSurfaceCreate*(dpy: PDisplay, drawable: TDrawable, visual: PVisual, width, height: int32): PSurface {.cdecl, importc: "cairo_xlib_surface_create", libcairo.}
 proc xlibSurfaceCreateForBitmap*(dpy: PDisplay, bitmap: TPixmap, screen: PScreen, width, height: int32): PSurface{. cdecl, importc: "cairo_xlib_surface_create_for_bitmap", libcairo.}
-proc xlibSurfaceCreateWithXrenderFormat*(dpy: PDisplay, drawable: TDrawable, screen: PScreen, format: PXRenderPictFormat, width, height: int32): PSurface{.cdecl, importc: "cairo_xlib_surface_create_with_xrender_format", libcairo.}
-proc xlibSurfaceGetDepth*(surface: PSurface): int32{.cdecl, importc: "cairo_xlib_surface_get_depth", libcairo.}
-proc xlibSurfaceGetDisplay*(surface: PSurface): PDisplay{.cdecl, importc: "cairo_xlib_surface_get_display", libcairo.}
-proc xlibSurfaceGetDrawable*(surface: PSurface): TDrawable{.cdecl, importc: "cairo_xlib_surface_get_drawable", libcairo.}
-proc xlibSurfaceGetHeight*(surface: PSurface): int32{.cdecl, importc: "cairo_xlib_surface_get_height", libcairo.}
-proc xlibSurfaceGetScreen*(surface: PSurface): PScreen{.cdecl, importc: "cairo_xlib_surface_get_screen", libcairo.}
-proc xlibSurfaceGetVisual*(surface: PSurface): PVisual{.cdecl, importc: "cairo_xlib_surface_get_visual", libcairo.}
-proc xlibSurfaceGetWidth*(surface: PSurface): int32{.cdecl, importc: "cairo_xlib_surface_get_width", libcairo.}
-proc xlibSurfaceSetSize*(surface: PSurface, width, height: int32){.cdecl, importc: "cairo_xlib_surface_set_size", libcairo.}
-proc xlibSurfaceSetDrawable*(surface: PSurface, drawable: TDrawable, width, height: int32){.cdecl, importc: "cairo_xlib_surface_set_drawable", libcairo.}
+proc xlibSurfaceCreateWithXrenderFormat*(dpy: PDisplay, drawable: TDrawable, screen: PScreen, format: PXRenderPictFormat, width, height: int32): PSurface {.cdecl, importc: "cairo_xlib_surface_create_with_xrender_format", libcairo.}
+proc xlibSurfaceGetDepth*(surface: PSurface): int32 {.cdecl, importc: "cairo_xlib_surface_get_depth", libcairo.}
+proc xlibSurfaceGetDisplay*(surface: PSurface): PDisplay {.cdecl, importc: "cairo_xlib_surface_get_display", libcairo.}
+proc xlibSurfaceGetDrawable*(surface: PSurface): TDrawable {.cdecl, importc: "cairo_xlib_surface_get_drawable", libcairo.}
+proc xlibSurfaceGetHeight*(surface: PSurface): int32 {.cdecl, importc: "cairo_xlib_surface_get_height", libcairo.}
+proc xlibSurfaceGetScreen*(surface: PSurface): PScreen {.cdecl, importc: "cairo_xlib_surface_get_screen", libcairo.}
+proc xlibSurfaceGetVisual*(surface: PSurface): PVisual {.cdecl, importc: "cairo_xlib_surface_get_visual", libcairo.}
+proc xlibSurfaceGetWidth*(surface: PSurface): int32 {.cdecl, importc: "cairo_xlib_surface_get_width", libcairo.}
+proc xlibSurfaceSetSize*(surface: PSurface, width, height: int32) {.cdecl, importc: "cairo_xlib_surface_set_size", libcairo.}
+proc xlibSurfaceSetDrawable*(surface: PSurface, drawable: TDrawable, width, height: int32) {.cdecl, importc: "cairo_xlib_surface_set_drawable", libcairo.}
 # implementation

--- a/src/cairoxlib.nim
+++ b/src/cairoxlib.nim
@@ -9,33 +9,16 @@ import
 
 include "cairo_pragma.nim"
 
-proc xlibSurfaceCreate*(dpy: PDisplay, drawable: TDrawable, visual: PVisual, 
-                          width, height: int32): PSurface{.cdecl, 
-    importc: "cairo_xlib_surface_create", libcairo.}
-proc xlibSurfaceCreateForBitmap*(dpy: PDisplay, bitmap: TPixmap, 
-                                     screen: PScreen, width, height: int32): PSurface{.
-    cdecl, importc: "cairo_xlib_surface_create_for_bitmap", libcairo.}
-proc xlibSurfaceCreateWithXrenderFormat*(dpy: PDisplay, 
-    drawable: TDrawable, screen: PScreen, format: PXRenderPictFormat, 
-    width, height: int32): PSurface{.cdecl, importc: "cairo_xlib_surface_create_with_xrender_format", 
-                                     libcairo.}
-proc xlibSurfaceGetDepth*(surface: PSurface): int32{.cdecl, 
-    importc: "cairo_xlib_surface_get_depth", libcairo.}
-proc xlibSurfaceGetDisplay*(surface: PSurface): PDisplay{.cdecl, 
-    importc: "cairo_xlib_surface_get_display", libcairo.}
-proc xlibSurfaceGetDrawable*(surface: PSurface): TDrawable{.cdecl, 
-    importc: "cairo_xlib_surface_get_drawable", libcairo.}
-proc xlibSurfaceGetHeight*(surface: PSurface): int32{.cdecl, 
-    importc: "cairo_xlib_surface_get_height", libcairo.}
-proc xlibSurfaceGetScreen*(surface: PSurface): PScreen{.cdecl, 
-    importc: "cairo_xlib_surface_get_screen", libcairo.}
-proc xlibSurfaceGetVisual*(surface: PSurface): PVisual{.cdecl, 
-    importc: "cairo_xlib_surface_get_visual", libcairo.}
-proc xlibSurfaceGetWidth*(surface: PSurface): int32{.cdecl, 
-    importc: "cairo_xlib_surface_get_width", libcairo.}
-proc xlibSurfaceSetSize*(surface: PSurface, width, height: int32){.cdecl, 
-    importc: "cairo_xlib_surface_set_size", libcairo.}
-proc xlibSurfaceSetDrawable*(surface: PSurface, drawable: TDrawable, 
-                                width, height: int32){.cdecl, 
-    importc: "cairo_xlib_surface_set_drawable", libcairo.}
+proc xlibSurfaceCreate*(dpy: PDisplay, drawable: TDrawable, visual: PVisual, width, height: int32): PSurface{.cdecl, importc: "cairo_xlib_surface_create", libcairo.}
+proc xlibSurfaceCreateForBitmap*(dpy: PDisplay, bitmap: TPixmap, screen: PScreen, width, height: int32): PSurface{. cdecl, importc: "cairo_xlib_surface_create_for_bitmap", libcairo.}
+proc xlibSurfaceCreateWithXrenderFormat*(dpy: PDisplay, drawable: TDrawable, screen: PScreen, format: PXRenderPictFormat, width, height: int32): PSurface{.cdecl, importc: "cairo_xlib_surface_create_with_xrender_format", libcairo.}
+proc xlibSurfaceGetDepth*(surface: PSurface): int32{.cdecl, importc: "cairo_xlib_surface_get_depth", libcairo.}
+proc xlibSurfaceGetDisplay*(surface: PSurface): PDisplay{.cdecl, importc: "cairo_xlib_surface_get_display", libcairo.}
+proc xlibSurfaceGetDrawable*(surface: PSurface): TDrawable{.cdecl, importc: "cairo_xlib_surface_get_drawable", libcairo.}
+proc xlibSurfaceGetHeight*(surface: PSurface): int32{.cdecl, importc: "cairo_xlib_surface_get_height", libcairo.}
+proc xlibSurfaceGetScreen*(surface: PSurface): PScreen{.cdecl, importc: "cairo_xlib_surface_get_screen", libcairo.}
+proc xlibSurfaceGetVisual*(surface: PSurface): PVisual{.cdecl, importc: "cairo_xlib_surface_get_visual", libcairo.}
+proc xlibSurfaceGetWidth*(surface: PSurface): int32{.cdecl, importc: "cairo_xlib_surface_get_width", libcairo.}
+proc xlibSurfaceSetSize*(surface: PSurface, width, height: int32){.cdecl, importc: "cairo_xlib_surface_set_size", libcairo.}
+proc xlibSurfaceSetDrawable*(surface: PSurface, drawable: TDrawable, width, height: int32){.cdecl, importc: "cairo_xlib_surface_set_drawable", libcairo.}
 # implementation


### PR DESCRIPTION
T* and P* is old style nim that is used less. More common to use just `name` and `ptr name`. Also a lot of the P* where used just once why a separate type?

Also re-flowed the huge C definitions so that they are easier to search and edit.

Also some spaces and formatting.