### PR TITLE
Look for cairo.dll on Windows if libcairo-2.dll is not found

### DIFF
--- a/src/cairo_pragma.nim
+++ b/src/cairo_pragma.nim
@@ -8,7 +8,7 @@ when declared(use_pkg_config) or declared(use_pkg_config_static):
     {.passl: gorge("pkg-config cairo --libs").}
 else:
   when defined(windows):
-    const LibCairo* = "libcairo-2.dll"
+    const LibCairo* = "(libcairo-2|cairo).dll"
   elif defined(macosx):
     const LibCairo* = "libcairo(|.2).dylib"
   else:


### PR DESCRIPTION
While typically the cairo dll is called `libcairo-2.dll`, there are some builds which call it `cairo.dll` (see for example https://github.com/preshing/cairo-windows). This causes problems for libraries like ggplotnim, which cannot just recommend users to download the stand-alone cairo library from the URL above because its dll is not called libcairo-2.dll.